### PR TITLE
PEP-8 fixes

### DIFF
--- a/toolz/functoolz/core.py
+++ b/toolz/functoolz/core.py
@@ -1,6 +1,7 @@
 from functools import reduce
 import itertools
 
+
 def identity(x):
     return x
 
@@ -103,6 +104,7 @@ def memoize(f, cache=None):
     """
     if cache == None:
         cache = {}
+
     def memof(*args):
         if not hashable(args):
             return f(*args)
@@ -185,6 +187,7 @@ def iterate(f, x):
     while True:
         yield x
         x = f(x)
+
 
 def accumulate(f, seq):
     """ Repeatedly apply binary function f to a sequence, accumulating results

--- a/toolz/functoolz/tests/test_core.py
+++ b/toolz/functoolz/tests/test_core.py
@@ -1,17 +1,30 @@
 from toolz.functoolz import (accumulate, iterate, remove,
-        thread_first, thread_last,
-        memoize, curry)
+                             thread_first, thread_last,
+                             memoize, curry)
 from operator import add, mul
 
 import itertools
 
-def even(x):           return x % 2 == 0
-def odd(x):            return x % 2 == 1
-def inc(x):            return x + 1
-def double(x):         return 2*x
+
+def even(x):
+    return x % 2 == 0
+
+
+def odd(x):
+    return x % 2 == 1
+
+
+def inc(x):
+    return x + 1
+
+
+def double(x):
+    return 2 * x
+
 
 def test_remove():
     assert list(remove(even, range(5))) == list(filter(odd, range(5)))
+
 
 def test_thread_first():
     assert thread_first(2) == 2
@@ -20,8 +33,10 @@ def test_thread_first():
     assert thread_first(2, double, inc) == 5
     assert thread_first(2, (add, 5), double) == 14
 
+
 def test_thread_last():
     assert list(thread_last([1, 2, 3], (map, inc), (filter, even))) == [2, 4]
+
 
 def test_memoize():
     fn_calls = [0]  # Storage for side effects
@@ -36,15 +51,18 @@ def test_memoize():
     assert fn_calls == [1]  # function was only called once
     assert mf.__doc__ == f.__doc__
 
+
 def test_curry_simple():
     cmul = curry(mul)
     double = cmul(2)
     assert callable(double)
     assert double(10) == 20
 
+
 def test_curry_kwargs():
     def f(a, b, c=10):
-        return (a + b)*c
+        return (a + b) * c
+
     f = curry(f)
     assert f(1, 2, 3) == 9
     assert f(1)(2, 3) == 9
@@ -52,8 +70,10 @@ def test_curry_kwargs():
     assert f(1, c=3)(2) == 9
     assert f(c=3)(1, 2) == 9
 
+
 def test_iterate():
     assert list(itertools.islice(iterate(inc, 0), 0, 5)) == [0, 1, 2, 3, 4]
+
 
 def test_accumulate():
     assert list(accumulate(add, [1, 2, 3, 4, 5])) == [1, 3, 6, 10, 15]

--- a/toolz/itertoolz/core.py
+++ b/toolz/itertoolz/core.py
@@ -231,7 +231,9 @@ second = partial(nth, 1)
 rest = partial(drop, 1)
 
 
-no_default='__no__default__'
+no_default = '__no__default__'
+
+
 def get(ind, seq, default=no_default):
     """ Get element in a sequence or dict
 

--- a/toolz/itertoolz/tests/test_core.py
+++ b/toolz/itertoolz/tests/test_core.py
@@ -1,12 +1,15 @@
 import itertools
 from toolz.utils import raises
 from functools import partial
-from toolz.itertoolz.core import (remove, groupby, merge_sorted, merge_dict,
-                       concat, concatv, interleave, unique, identity,
-                       intersection, iterable, mapcat, distinct,
-                       first, second, nth, take, drop, interpose, get,
-                       rest, last, cons)
+from toolz.itertoolz.core import (remove, groupby, merge_sorted,
+                                  merge_dict, concat, concatv,
+                                  interleave, unique, identity,
+                                  intersection, iterable, mapcat,
+                                  distinct, first, second, nth, take,
+                                  drop, interpose, get, rest, last,
+                                  cons)
 from toolz.compatibility import range
+
 
 def even(x):
     return x % 2 == 0
@@ -107,8 +110,8 @@ def test_get():
 
     assert get('foo', {}, default='bar') == 'bar'
 
-    assert raises(IndexError, lambda : get(10, 'ABC'))
-    assert raises(KeyError, lambda : get(10, {'a': 1}))
+    assert raises(IndexError, lambda: get(10, 'ABC'))
+    assert raises(KeyError, lambda: get(10, {'a': 1}))
 
 
 def test_mapcat():

--- a/toolz/tests/test_utils.py
+++ b/toolz/tests/test_utils.py
@@ -1,5 +1,6 @@
 from toolz.utils import raises
 
+
 def test_raises():
-    assert raises(ZeroDivisionError, lambda : 1/0)
-    assert not raises(ZeroDivisionError, lambda : 1)
+    assert raises(ZeroDivisionError, lambda: 1 / 0)
+    assert not raises(ZeroDivisionError, lambda: 1)


### PR DESCRIPTION
Some of these changes do increase vertical whitespace a tad but I do think it's helpful to have the common standard, so here are the edits required to pass pep8.  Tested with Py 2.x and 3.
