### PR TITLE
Fully-qualified all imports in __init__.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from os.path import exists
 from setuptools import setup
 

--- a/toolz/__init__.py
+++ b/toolz/__init__.py
@@ -1,15 +1,14 @@
-from .itertoolz import (groupby, countby, frequencies, reduceby,
-        first, second, nth, take, drop, rest, last, get,
-        merge_sorted, concat, mapcat,
-        interleave, unique, intersection, iterable, distinct)
+from toolz.itertoolz import (groupby, countby, frequencies, reduceby,
+                             first, second, nth, take, drop, rest,
+                             last, get, merge_sorted, concat, mapcat,
+                             interleave, unique, intersection,
+                             iterable, distinct)
+from toolz.functoolz import (remove, iterate, accumulate, memoize,
+                             curry, compose, thread_first,
+                             thread_last)
+from toolz.dicttoolz import merge, keymap, valmap, assoc, update_in
 
-from .functoolz import (remove, iterate, accumulate,
-        memoize, curry, compose,
-        thread_first, thread_last)
-
-from .dicttoolz import merge, keymap, valmap, assoc, update_in
-
-from .compatibility import map, filter
+from toolz.compatibility import map, filter
 
 # Aliases
 comp = compose

--- a/toolz/dicttoolz/__init__.py
+++ b/toolz/dicttoolz/__init__.py
@@ -1,1 +1,1 @@
-from .core import merge, valmap, keymap, update_in, assoc
+from toolz.dicttoolz.core import merge, valmap, keymap, update_in, assoc

--- a/toolz/functoolz/__init__.py
+++ b/toolz/functoolz/__init__.py
@@ -1,2 +1,3 @@
-from .core import (remove, iterate, accumulate, memoize, curry,
-                   thread_first, thread_last, compose)
+from toolz.functoolz.core import (remove, iterate, accumulate,
+                                  memoize, curry, thread_first,
+                                  thread_last, compose)

--- a/toolz/itertoolz/__init__.py
+++ b/toolz/itertoolz/__init__.py
@@ -1,6 +1,9 @@
-from .core import (groupby, remove, concat, concatv, mapcat, frequencies,
-                   interpose, first, second, nth, take, drop, rest, get,
-                   last, merge_sorted, interleave, unique, reduceby,
-                   identity, intersection, iterable, distinct, cons)
+from toolz.itertoolz.core import (groupby, remove, concat, concatv,
+                                  mapcat, frequencies, interpose,
+                                  first, second, nth, take, drop,
+                                  rest, get, last, merge_sorted,
+                                  interleave, unique, reduceby,
+                                  identity, intersection, iterable,
+                                  distinct, cons)
 
-from .recipes import countby
+from toolz.itertoolz.recipes import countby


### PR DESCRIPTION
This is slightly uglier than the existing `from .blah import X` but I
suspect it will fix #28. I have no way to test this but it passes
`nosetests` on 2.6 (I'll let TravisCI tell us about 3.x).

Minor tweak - made setup.py executable since I am in the habit of
typing `./setup.py develop`.

@mrocklin - can you think of a better way to do this?  Issue #28 is a complete showstopper for me being able to use this library.
