### PR TITLE
Minor typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Structure and Heritage
 `toolz` is implemented in three parts:
 
 [`itertoolz`](https://github.com/pytoolz/toolz/blob/master/toolz/itertoolz/core.py),
-for opertions on iterables.  Examples: `groupby`, `unique`, `interpose`,
+for operations on iterables.  Examples: `groupby`, `unique`, `interpose`,
 
 [`functoolz`](https://github.com/pytoolz/toolz/blob/master/toolz/functoolz/core.py),
 for higher-order functions.  Examples: `memoize`, `curry`, `compose`

--- a/doc/source/curry.rst
+++ b/doc/source/curry.rst
@@ -74,7 +74,7 @@ compute a result.
 
     >>> double = mul(2)     # mul didn't receive enough arguments to evaluate
     ...                     # so it holds onto the 2 and waits, returning a
-    ...                     # partially evaluted function, double
+    ...                     # partially evaluated function, double
 
     >>> double(5)
     10

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -2,7 +2,7 @@ Installation and Dependencies
 =============================
 
 Toolz is pure Python and so is easily installable by the standard
-dependency manageers ``pip`` and ``easy_install``::
+dependency managers ``pip`` and ``easy_install``::
 
     easy_install toolz
 


### PR DESCRIPTION
A couple of very minor typos spotted while reading the _excellent_ documentation.

Perhaps it is a cultural thing, but is "irregardless" from `doc/source/control.rst` a word?

Thanks,

James
