### PR TITLE
Curry errors

### DIFF
--- a/toolz/dicttoolz/core.py
+++ b/toolz/dicttoolz/core.py
@@ -85,4 +85,4 @@ def update_in(d, keys, f):
         return assoc(d, keys[0], f(d.get(keys[0], None)))
     else:
         return assoc(d, keys[0], update_in(d.get(keys[0], None),
-                                              keys[1:], f))
+                                           keys[1:], f))

--- a/toolz/functoolz/core.py
+++ b/toolz/functoolz/core.py
@@ -104,7 +104,7 @@ def memoize(f, cache=None):
     ... def add(x, y):
     ...     return x + y
     """
-    if cache == None:
+    if cache is None:
         cache = {}
 
     def memof(*args):
@@ -195,7 +195,6 @@ class curry(object):
         kwargs = {}
         kwargs.update(self.kwargs)
         kwargs.update(_kwargs)
-
 
         required_args = _num_required_args(self.func)
         if (required_args is not None):

--- a/toolz/functoolz/tests/test_core.py
+++ b/toolz/functoolz/tests/test_core.py
@@ -77,9 +77,9 @@ def test_curry_passes_errors():
         return a + b
 
     assert f(1, 2) == 3
-    assert raises(TypeError, lambda : f('1', 2))
-    assert raises(TypeError, lambda : f('1')(2))
-    assert raises(TypeError, lambda : f(1, 2, 3))
+    assert raises(TypeError, lambda: f('1', 2))
+    assert raises(TypeError, lambda: f('1')(2))
+    assert raises(TypeError, lambda: f(1, 2, 3))
 
 
 def test_curry_docstring():

--- a/toolz/itertoolz/tests/test_core.py
+++ b/toolz/itertoolz/tests/test_core.py
@@ -59,17 +59,17 @@ def test_intersection():
 
 
 def test_isiterable():
-    assert isiterable([1, 2, 3]) == True
-    assert isiterable('abc') == True
-    assert isiterable(5) == False
+    assert isiterable([1, 2, 3]) is True
+    assert isiterable('abc') is True
+    assert isiterable(5) is False
 
 
 def test_isdistinct():
-    assert isdistinct([1, 2, 3]) == True
-    assert isdistinct([1, 2, 1]) == False
+    assert isdistinct([1, 2, 3]) is True
+    assert isdistinct([1, 2, 1]) is False
 
-    assert isdistinct("Hello") == False
-    assert isdistinct("World") == True
+    assert isdistinct("Hello") is False
+    assert isdistinct("World") is True
 
 
 def test_nth():


### PR DESCRIPTION
Previously curry hid a number of errors in user code.  In particular any `TypeError` was assumed to be the cause of not-enough-arguments.  Now we use the `inspect` module to determine the number of required args ahead of time.
