### PR TITLE
add `dicttoolz.merge_with`

### DIFF
--- a/toolz/__init__.py
+++ b/toolz/__init__.py
@@ -8,7 +8,7 @@ from .itertoolz import (groupby, countby, frequencies, reduceby,
 from .functoolz import (memoize, curry, compose, thread_first,
                         thread_last, identity, pipe)
 
-from .dicttoolz import merge, keymap, valmap, assoc, update_in
+from .dicttoolz import merge, merge_with, keymap, valmap, assoc, update_in
 
 from .compatibility import map, filter
 

--- a/toolz/dicttoolz/__init__.py
+++ b/toolz/dicttoolz/__init__.py
@@ -1,1 +1,1 @@
-from .core import merge, valmap, keymap, update_in, assoc
+from .core import merge, merge_with, valmap, keymap, update_in, assoc

--- a/toolz/dicttoolz/core.py
+++ b/toolz/dicttoolz/core.py
@@ -8,11 +8,35 @@ def merge(*dicts):
 
     >>> merge({1: 2, 3: 4}, {3: 3, 4: 4})
     {1: 2, 3: 3, 4: 4}
+
+    See Also:
+        merge_with
     """
     rv = dict()
     for d in dicts:
         rv.update(d)
     return rv
+
+
+def merge_with(fn, *dicts):
+    """ Merge dictionaries and apply function to combined values
+
+    A key may occur in more than one dict, and all values mapped from the key
+    will be passed to the function as a list, such as fn([val1, val2, ...]).
+
+    >>> merge_with(sum, {1: 1, 2: 2}, {1: 10, 2: 20})
+    {1: 11, 2: 22}
+
+    >>> merge_with(first, {1: 1, 2: 2}, {2: 20, 3: 30})  # doctest: +SKIP
+    {1: 1, 2: 2, 3: 30}
+
+    See Also:
+        merge
+    """
+    keys = tuple(set((k for d in dicts for k in d)))
+    values = tuple(fn([d[k] for d in dicts if k in d])
+                            for k in keys)
+    return dict(zip(keys, values))
 
 
 def valmap(fn, d):

--- a/toolz/dicttoolz/tests/test_core.py
+++ b/toolz/dicttoolz/tests/test_core.py
@@ -1,5 +1,5 @@
 from toolz.utils import raises
-from toolz.dicttoolz import merge, valmap, keymap, update_in, assoc
+from toolz.dicttoolz import merge, merge_with, valmap, keymap, update_in, assoc
 
 
 inc = lambda x: x + 1
@@ -7,6 +7,16 @@ inc = lambda x: x + 1
 
 def test_merge():
     assert merge({1: 1, 2: 2}, {3: 4}) == {1: 1, 2: 2, 3: 4}
+
+
+def test_merge_with():
+    dicts = {1: 1, 2: 2}, {1: 10, 2: 20}
+    assert merge_with(sum, *dicts) == {1: 11, 2: 22}
+    assert merge_with(tuple, *dicts) == {1: (1, 10), 2: (2, 20)}
+
+    dicts = {1: 1, 2: 2, 3: 3}, {1: 10, 2: 20}
+    assert merge_with(sum, *dicts) == {1: 11, 2: 22, 3: 3}
+    assert merge_with(tuple, *dicts) == {1: (1, 10), 2: (2, 20), 3: (3,)}
 
 
 def test_valmap():


### PR DESCRIPTION
Like `dicttoolz.merge`, but applies a function to the values of a key.

From #49

Note that #49 included the ability to pass an iterable of dicts.  This PR does not.
