### PR TITLE
add sorted to curried namespace

### DIFF
--- a/toolz/__init__.py
+++ b/toolz/__init__.py
@@ -14,6 +14,8 @@ from .compatibility import map, filter
 
 from functools import partial, reduce
 
+sorted = sorted
+
 # Aliases
 comp = compose
 

--- a/toolz/curried.py
+++ b/toolz/curried.py
@@ -37,7 +37,7 @@ def nargs(f):
 
 
 def should_curry(f):
-    do_curry = set((toolz.map, toolz.filter))
+    do_curry = set((toolz.map, toolz.filter, toolz.sorted))
     return (callable(f) and nargs(f) and nargs(f) > 1
             or f in do_curry)
 

--- a/toolz/tests/test_curried.py
+++ b/toolz/tests/test_curried.py
@@ -1,5 +1,5 @@
 import toolz
-from toolz.curried import take, first
+from toolz.curried import take, first, second, sorted
 
 
 def test_take():
@@ -8,3 +8,7 @@ def test_take():
 
 def test_first():
     assert first is toolz.itertoolz.core.first
+
+
+def test_sorted():
+    assert sorted(key=second)([(1, 2), (2, 1)]) == [(2, 1), (1, 2)]


### PR DESCRIPTION
This allows a curried `sorted(key=func, reverse=True)` to be used within functions like `compose` and `pipe`
