### PR TITLE
MUCH faster `last` for non-sequences by using a deque

### DIFF
--- a/toolz/itertoolz/core.py
+++ b/toolz/itertoolz/core.py
@@ -271,13 +271,7 @@ def last(seq):
     try:
         return seq[-1]
     except (TypeError, KeyError):
-        old = None
-        it = iter(seq)
-        while True:
-            try:
-                old = next(it)
-            except StopIteration:
-                return old
+        return collections.deque(seq, 1)[0]
 
 
 rest = partial(drop, 1)


### PR DESCRIPTION
10x faster than the replaced code.
