### PR TITLE
`get` is faster for list of indices with no default

### DIFF
--- a/toolz/itertoolz/core.py
+++ b/toolz/itertoolz/core.py
@@ -1,9 +1,9 @@
-import heapq
 import itertools
+import heapq
+import collections
+import operator
 from functools import partial
 from toolz.compatibility import map, filter, zip, zip_longest
-import collections
-
 
 identity = lambda x: x
 
@@ -330,7 +330,7 @@ def get(ind, seq, default=no_default):
     except TypeError:  # `ind` may be a list
         if isinstance(ind, list):
             if default is no_default:
-                return tuple(seq[i] for i in ind)
+                return operator.itemgetter(*ind)(seq)
             else:
                 return tuple(_get(i, seq, default) for i in ind)
         elif default is not no_default:


### PR DESCRIPTION
PR #57 put an emphasis on the performance of `get` because it is
so frequently used.  Some timings for `get` were given in that thread.
This commit improves those benchmarks as follows:

"test list" is 50% faster (using a two-element list of indices).
"test long list" is 100% faster (using a 100-element list of indices).

This is achieved because `operator.itemgetter(*ind)(seq)` is significantly
faster than `tuple(seq[i] for i in ind)`.  For me, it is 3x faster.
