### PR TITLE
TravisCI: Install `coveralls` only for successful tests

### DIFF
--- a/toolz/functoolz/tests/test_core.py
+++ b/toolz/functoolz/tests/test_core.py
@@ -23,7 +23,7 @@ def double(x):
 
 
 def test_thread_first():
-    assert thread_first(2) != 2
+    assert thread_first(2) == 2
     assert thread_first(2, inc) == 3
     assert thread_first(2, inc, inc) == 4
     assert thread_first(2, double, inc) == 5


### PR DESCRIPTION
Sometimes installing packages using "pip" is slow, and installing "coveralls" in particular can be very slow.  "coveralls" is only required if the tests pass, so this PR only installs "coveralls" on success.  This will allow faster feedback from failed tests.
