### PR TITLE
remove intersection

### DIFF
--- a/toolz/__init__.py
+++ b/toolz/__init__.py
@@ -1,7 +1,7 @@
 from .itertoolz import (groupby, countby, frequencies, reduceby,
                         first, second, nth, take, drop, rest, last,
                         get, merge_sorted, concat, concatv, mapcat,
-                        isdistinct, interleave, unique, intersection,
+                        isdistinct, interleave, unique,
                         isiterable, remove, iterate, accumulate,
                         partitionby, partition, partition_all,
                         sliding_window, count)

--- a/toolz/itertoolz/__init__.py
+++ b/toolz/itertoolz/__init__.py
@@ -1,7 +1,7 @@
 from .core import (groupby, remove, concat, concatv, mapcat,
                    frequencies, interpose, first, second, nth, take,
                    drop, rest, get, last, merge_sorted, interleave,
-                   unique, reduceby, intersection, isiterable,
+                   unique, reduceby, isiterable,
                    isdistinct, cons, iterate, accumulate, sliding_window,
                    count, partition, partition_all)
 

--- a/toolz/itertoolz/core.py
+++ b/toolz/itertoolz/core.py
@@ -174,16 +174,6 @@ def unique(seq, key=identity):
             yield item
 
 
-def intersection(*seqs):
-    """ Lazily evaluated intersection of sequences
-
-    >>> list(intersection([1, 2, 3], [2, 3, 4]))
-    [2, 3]
-    """
-    return (item for item in seqs[0]
-            if all(item in seq for seq in seqs[1:]))
-
-
 def isiterable(x):
     """ Is x iterable?
 

--- a/toolz/itertoolz/tests/test_core.py
+++ b/toolz/itertoolz/tests/test_core.py
@@ -3,7 +3,7 @@ from toolz.utils import raises
 from functools import partial
 from toolz.itertoolz.core import (remove, groupby, merge_sorted,
                                   concat, concatv, interleave, unique,
-                                  identity, intersection, isiterable,
+                                  identity, isiterable,
                                   mapcat, isdistinct, first, second,
                                   nth, take, drop, interpose, get,
                                   rest, last, cons, frequencies,
@@ -65,11 +65,6 @@ def test_unique():
     assert tuple(unique((1, 2, 3))) == (1, 2, 3)
     assert tuple(unique((1, 2, 1, 3))) == (1, 2, 3)
     assert tuple(unique((1, 2, 3), key=iseven)) == (1, 2)
-
-
-def test_intersection():
-    assert list(intersection([1, 2, 3], [2, 3, 4])) == [2, 3]
-    assert list(intersection([3, 4], itertools.count(0))) == [3, 4]
 
 
 def test_isiterable():


### PR DESCRIPTION
My solution to #90 is to delete intersection

We don't have a good use case for this, the builtin `set.intersection` works well in most cases, and I'd like to set the example of maintaining a very small API.
