### PR TITLE
Fix OverflowError from tests on 32bit systems.

### DIFF
--- a/toolz/itertoolz/tests/test_core.py
+++ b/toolz/itertoolz/tests/test_core.py
@@ -167,7 +167,7 @@ def test_concatv():
 
 
 def test_interpose():
-    assert "a" == first(rest(interpose("a", range(10000000000))))
+    assert "a" == first(rest(interpose("a", range(1000000000))))
     assert "tXaXrXzXaXn" == "".join(interpose("X", "tarzan"))
     assert list(interpose(0, itertools.repeat(1, 4))) == [1, 0, 1, 0, 1, 0, 1]
     assert list(interpose('.', ['a', 'b', 'c'])) == ['a', '.', 'b', '.', 'c']


### PR DESCRIPTION
This fixes the following error that occurs while executing the tests on a 32-bit system:

``` python
======================================================================
ERROR: test_core.test_interpose
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/erikw/git/toolz/toolz/itertoolz/tests/test_core.py", line 170, in test_interpose
    assert "a" == first(rest(interpose("a", range(10000000000))))
OverflowError: Python int too large to convert to C long
```
