### PR TITLE
sliding window aborts if iterator is too short

### DIFF
--- a/toolz/itertoolz/core.py
+++ b/toolz/itertoolz/core.py
@@ -509,6 +509,8 @@ def sliding_window(n, seq):
     it = iter(seq)
     # An efficient FIFO data structure with maximum length
     d = collections.deque(itertools.islice(it, n), n)
+    if len(d) != n:
+        raise StopIteration()
     for item in it:
         yield tuple(d)
         d.append(item)

--- a/toolz/itertoolz/tests/test_core.py
+++ b/toolz/itertoolz/tests/test_core.py
@@ -216,6 +216,10 @@ def test_sliding_window():
     assert list(sliding_window(3, [1, 2, 3, 4])) == [(1, 2, 3), (2, 3, 4)]
 
 
+def test_sliding_window_of_short_iterator():
+    assert list(sliding_window(3, [1, 2])) == []
+
+
 def test_partition():
     assert list(partition(2, [1, 2, 3, 4])) == [(1, 2), (3, 4)]
     assert list(partition(3, range(7))) == [(0, 1, 2), (3, 4, 5)]


### PR DESCRIPTION
Current behavior results in an iterator that contains a tuple of size shorter than `n`.  I'm not sure what expected behavior is in this situation.

This commit allows the assertion that all elements coming out of `sliding_window` have length `n`.  
