### PR TITLE
remove __all__ from curried_exceptions

### DIFF
--- a/toolz/curried_exceptions.py
+++ b/toolz/curried_exceptions.py
@@ -1,7 +1,5 @@
 import toolz
 
-__all__ = ['merge_with']
-
 
 def merge_with(fn, *dicts):
     if len(dicts) == 0:


### PR DESCRIPTION
This all was merged into curried.py 's namespace, limiting
from toolz.curried import \* statements
