### PR TITLE
Reimplement 'groupby' and 'frequencies' using 'collections.defaultdict'

### DIFF
--- a/toolz/itertoolz/core.py
+++ b/toolz/itertoolz/core.py
@@ -63,7 +63,7 @@ def groupby(func, seq):
     d = collections.defaultdict(list)
     for item in seq:
         d[func(item)].append(item)
-    return d
+    return dict(d)
 
 
 def merge_sorted(*seqs, **kwargs):
@@ -417,7 +417,7 @@ def frequencies(seq):
     d = collections.defaultdict(int)
     for item in seq:
         d[item] += 1
-    return d
+    return dict(d)
 
 
 def reduceby(key, binop, seq, init):


### PR DESCRIPTION
`collections.defaultdict` to replace explicit `if` and `try` in `groupby` and `frequencies` respectively, yielding more concise code and encouraging more use of the standard library.

P.S. `collections.Counter` could've been used in `frequencies` instead of `collections.defaultdict`, but is not supported in Python 2.6.
