### PR TITLE
Update broken links: "LICENSE.txt" gets a full-path link, and don't point to "http://crate.io" anymore.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ See the PyToolz documentation at http://toolz.readthedocs.org
 LICENSE
 -------
 
-New BSD. See `License File <LICENSE.TXT>`__.
+New BSD. See `License File <https://github.com/pytoolz/toolz/blob/master/LICENSE.txt>`__.
 
 Install
 -------
@@ -116,6 +116,6 @@ ideas.
 .. |Coverage Status| image:: https://coveralls.io/repos/pytoolz/toolz/badge.png
    :target: https://coveralls.io/r/pytoolz/toolz
 .. |Version Status| image:: https://pypip.in/v/toolz/badge.png
-   :target: https://crate.io/packages/toolz/
+   :target: https://pypi.python.org/pypi/toolz/
 .. |Downloads| image:: https://pypip.in/d/toolz/badge.png
-   :target: https://crate.io/packages/toolz/
+   :target: https://pypi.python.org/pypi/toolz/


### PR DESCRIPTION
RST readme files don't render properly on PyPI when there is a broken link, and the link to "LICENSE.txt" was a local reference and, hence, is regarded as broken.  This PR provides a full path link to LICENSE.txt.  Hopefully this will make the readme render properly on pypi.  See the `toolz` page on pypi here:

https://pypi.python.org/pypi/toolz/

Interestingly, the readme renders just fine in the preview of the next generation PyPI (just as it also displayed fine on crate.io):

https://preview-pypi.python.org/project/toolz/

Next, https://crate.io has been mysteriously taken over by http://crate-technology.com , although they do redirect links back to pypi.  This PR changes links to point directly to pypi.python.org instead of crate.io.  So much for trying new, shiny things!
