### PR TITLE
Add compatibility functions to iterate over dict contents as discussed in #133.

### DIFF
--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -1,3 +1,4 @@
+import operator
 import sys
 PY3 = sys.version_info[0] > 2
 
@@ -8,6 +9,9 @@ if PY3:
     zip = zip
     from functools import reduce
     from itertools import zip_longest
+    iteritems = operator.methodcaller('items')
+    iterkeys = operator.methodcaller('keys')
+    itervalues = operator.methodcaller('values')
 else:
     range = xrange
     reduce = reduce
@@ -15,3 +19,6 @@ else:
     from itertools import ifilter as filter
     from itertools import izip as zip
     from itertools import izip_longest as zip_longest
+    iteritems = operator.methodcaller('iteritems')
+    iterkeys = operator.methodcaller('iterkeys')
+    itervalues = operator.methodcaller('itervalues')

--- a/toolz/dicttoolz/core.py
+++ b/toolz/dicttoolz/core.py
@@ -1,3 +1,6 @@
+from toolz.compatibility import map, zip, iteritems, iterkeys, itervalues
+
+
 def merge(*dicts):
     """ Merge a collection of dictionaries
 
@@ -41,12 +44,12 @@ def merge_with(func, *dicts):
 
     result = dict()
     for d in dicts:
-        for k, v in d.items():
+        for k, v in iteritems(d):
             try:
                 result[k].append(v)
             except:
                 result[k] = [v]
-    return dict((k, func(v)) for k, v in result.items())
+    return dict((k, func(v)) for k, v in iteritems(result))
 
 
 def valmap(func, d):
@@ -59,7 +62,7 @@ def valmap(func, d):
     See Also:
         keymap
     """
-    return dict(zip(d.keys(), map(func, d.values())))
+    return dict(zip(iterkeys(d), map(func, itervalues(d))))
 
 
 def keymap(func, d):
@@ -72,7 +75,7 @@ def keymap(func, d):
     See Also:
         valmap
     """
-    return dict(zip(map(func, d.keys()), d.values()))
+    return dict(zip(map(func, iterkeys(d)), itervalues(d)))
 
 
 def assoc(d, key, value):

--- a/toolz/tests/test_compatibility.py
+++ b/toolz/tests/test_compatibility.py
@@ -1,4 +1,4 @@
-from toolz.compatibility import map, filter
+from toolz.compatibility import map, filter, iteritems, iterkeys, itervalues
 
 
 def test_map_filter_are_lazy():
@@ -6,3 +6,13 @@ def test_map_filter_are_lazy():
         raise Exception()
     map(bad, [1, 2, 3])
     filter(bad, [1, 2, 3])
+
+
+def test_dict_iteration():
+    d = {'a': 1, 'b': 2, 'c': 3}
+    assert not isinstance(iteritems(d), list)
+    assert not isinstance(iterkeys(d), list)
+    assert not isinstance(itervalues(d), list)
+    assert set(iteritems(d)) == set(d.items())
+    assert set(iterkeys(d)) == set(d.keys())
+    assert set(itervalues(d)) == set(d.values())


### PR DESCRIPTION
`iteritems = operator.methodcaller("iteritems")` was used instead of `iteritems = dict.iteritems` to allow maximum compatibility with any dict-like object that supports the mapping protocol.  The former is also _slightly_ faster for me in Python 2 (Python 3 and pypy were not benchmarked).
