### PR TITLE
FIx issue #133: Reimplement 'assoc' with 'merge'

### DIFF
--- a/toolz/dicttoolz/core.py
+++ b/toolz/dicttoolz/core.py
@@ -89,9 +89,7 @@ def assoc(d, key, value):
     >>> assoc({'x': 1}, 'y', 3)   # doctest: +SKIP
     {'x': 1, 'y': 3}
     """
-    d = d.copy()
-    d[key] = value
-    return d
+    return merge(d, {key: value})
 
 
 def update_in(d, keys, func, default=None):


### PR DESCRIPTION
I would like to resolve #133. `assoc` now reuses `merge`.
