### PR TITLE
Improve performance of `merge_with` as discussed in #132

### DIFF
--- a/toolz/dicttoolz/core.py
+++ b/toolz/dicttoolz/core.py
@@ -20,7 +20,7 @@ def merge(*dicts):
     if len(dicts) == 1 and not isinstance(dicts[0], dict):
         dicts = dicts[0]
 
-    rv = dict()
+    rv = {}
     for d in dicts:
         rv.update(d)
     return rv
@@ -44,13 +44,13 @@ def merge_with(func, *dicts):
     if len(dicts) == 1 and not isinstance(dicts[0], dict):
         dicts = dicts[0]
 
-    result = dict()
+    result = {}
     for d in dicts:
         for k, v in iteritems(d):
-            try:
-                result[k].append(v)
-            except:
+            if k not in result:
                 result[k] = [v]
+            else:
+                result[k].append(v)
     return dict((k, func(v)) for k, v in iteritems(result))
 
 


### PR DESCRIPTION
See benchmark discussion and alternative implementations in #132.  Thanks to @microamp for starting the discussion and providing base benchmarks.

Also note the following benchmarks, which are why I changed `dict()` to `{}`:

``` python
In [1]: %timeit {}
10000000 loops, best of 3: 70.8 ns per loop

In [2]: %timeit dict()
1000000 loops, best of 3: 396 ns per loop
```
