### PR TITLE
See #139.  Raise original errors from `curry` (and `get`).

### DIFF
--- a/toolz/functoolz/core.py
+++ b/toolz/functoolz/core.py
@@ -220,12 +220,12 @@ class curry(object):
 
         try:
             return self.func(*args, **kwargs)
-        except TypeError as e:
+        except TypeError:
             required_args = _num_required_args(self.func)
 
             # If there was a genuine TypeError
             if required_args is not None and len(args) >= required_args:
-                raise e
+                raise
 
             # If we only need one more argument
             if (required_args is not None and required_args - len(args) == 1):

--- a/toolz/itertoolz/core.py
+++ b/toolz/itertoolz/core.py
@@ -336,9 +336,9 @@ def get(ind, seq, default=no_default):
             return default
         else:
             raise
-    except (KeyError, IndexError) as e:  # we know `ind` is not a list
+    except (KeyError, IndexError):  # we know `ind` is not a list
         if default is no_default:
-            raise e
+            raise
         else:
             return default
 


### PR DESCRIPTION
Previously, exceptions were reraised and reported from within `curry`, which is not particularly informative or helpful to the user.
