### PR TITLE
Replace side_effects with do in sandbox

### DIFF
--- a/toolz/sandbox/__init__.py
+++ b/toolz/sandbox/__init__.py
@@ -1,2 +1,2 @@
-from .core import jackknife, side_effects
+from .core import jackknife, do
 from .parallel import fold

--- a/toolz/sandbox/core.py
+++ b/toolz/sandbox/core.py
@@ -54,13 +54,12 @@ def do(func, x):
     Because the results of ``func`` are not returned, only the side
     effects of ``func`` are relevant.
 
-    >>> from __future__ import print_function
+    Logging functions can be made by composing ``do`` with a storage function
+    like ``list.append`` or ``file.write``
+
     >>> from toolz import compose, curry
     >>> from toolz.sandbox.core import do
     >>> do = curry(do)
-
-    Logging functions can be made by composing ``do`` with a storage function
-    like ``list.append`` or ``file.write``
 
     >>> log = []
     >>> inc = lambda x: x + 1
@@ -75,23 +74,3 @@ def do(func, x):
     """
     func(x)
     return x
-
-
-def side_effects(func, seq):
-    """ Apply func to each item in seq as a side effect.  Yield original item
-
-    >>> def say_hello(x):
-    ...     print("Hello, " + str(x) + "!")
-
-    >>> seq = (1, 2, 3)
-    >>> seq2 = side_effects(say_hello, seq)
-    >>> total = sum(seq2)
-    Hello, 1!
-    Hello, 2!
-    Hello, 3!
-    >>> total
-    6
-    """
-    for item in seq:
-        func(item)
-        yield item

--- a/toolz/sandbox/tests/test_core.py
+++ b/toolz/sandbox/tests/test_core.py
@@ -1,4 +1,4 @@
-from toolz.sandbox.core import jackknife, side_effects
+from toolz.sandbox.core import jackknife, do
 
 
 def test_jacknife():
@@ -12,10 +12,10 @@ def test_jacknife():
     assert tuple(tuple(x) for x in jackknife([1], replace=0)) == ((0,),)
 
 
-def test_side_effects():
-    results = []
-    seq = iter((1, 2, 3))
-    seq2 = side_effects(results.append, seq)
-    for i in seq2:
-        pass
-    assert results == [1, 2, 3]
+def test_do():
+    inc = lambda x: x + 1
+    assert do(inc, 1) == 1
+
+    log = []
+    assert do(log.append, 1) == 1
+    assert log == [1]


### PR DESCRIPTION
The `side_effects` routine is just `do` with a `map`.  Lets factor it out.

```
side_effects(f, seq) is map(do(f), seq)
```

or

```
side_effects(f) is map(do(f))
```
