### PR TITLE
Change `curry` to use `functools.partial`

### DIFF
--- a/toolz/functoolz/core.py
+++ b/toolz/functoolz/core.py
@@ -105,7 +105,86 @@ def _num_required_args(func):
         return None
 
 
-class curry(object):
+def _may_have_kwargs(func):
+    """ Whether a function may have keyword arguments."""
+    try:
+        spec = inspect.getargspec(func)
+        return bool(not spec or spec.keywords or spec.defaults)
+    except TypeError:
+        return True
+
+
+def _is_unary(func, spec=None):
+    """ Whether func is a unary functions (single argument input only)"""
+    try:
+        spec = inspect.getargspec(func)
+        return (spec and spec.varargs is None and spec.keywords is None
+                and spec.defaults is None and len(spec.args) == 1)
+    except TypeError:
+        return False
+
+
+class Curry(object):
+    """ A curried function
+
+    See Also:
+        curry
+    """
+    def __init__(self, func, *args, **kwargs):
+        if not callable(func):
+            raise TypeError("Input must be callable")
+
+        if kwargs:
+            self._call = partial(func, *args, **kwargs)
+        else:
+            self._call = partial(func, *args)
+        self.__doc__ = func.__doc__
+        try:
+            self.func_name = self.func.func_name
+        except AttributeError:
+            pass
+
+    @property
+    def func(self):
+        return self._call.func
+
+    @property
+    def args(self):
+        return self._call.args
+
+    @property
+    def keywords(self):
+        return self._call.keywords
+
+    def __str__(self):
+        return str(self.func)
+
+    def __repr__(self):
+        return repr(self.func)
+
+    def __call__(self, *args, **kwargs):
+        try:
+            return self._call(*args, **kwargs)
+        except TypeError:
+            required_args = _num_required_args(self.func)
+
+            # If there was a genuine TypeError
+            if (required_args is not None and
+                    len(args) + len(self.args) >= required_args):
+                raise
+
+            return curry(self._call, *args, **kwargs)
+
+    # pickle protocol because functools.partial objects can't be pickled
+    def __getstate__(self):
+        return self.func, self.args, self.keywords
+
+    def __setstate__(self, state):
+        func, args, kwargs = state
+        self.__init__(func, *args, **(kwargs or {}))
+
+
+def curry(func, *args, **kwargs):
     """ Curry a callable function
 
     Enables partial application of arguments through calling a function with an
@@ -129,73 +208,30 @@ class curry(object):
     >>> add(2, 3)
     5
 
+    For performance reasons, ``curry`` or a curried function will return a
+    ``functools.partial`` instance if only one more argument is required
+    and the function has no keywords.
+
     See Also:
         toolz.curried - namespace of curried functions
                         http://toolz.readthedocs.org/en/latest/curry.html
     """
-    def __init__(self, func, *args, **kwargs):
-        if not callable(func):
-            raise TypeError("Input must be callable")
+    # curry- or functools.partial-like object?  Unpack and merge arguments
+    if (hasattr(func, 'func') and hasattr(func, 'args')
+            and hasattr(func, 'keywords')):
+        _kwargs = {}
+        if func.keywords:
+            _kwargs.update(func.keywords)
+        _kwargs.update(kwargs)
+        kwargs = _kwargs
+        args = func.args + args
+        func = func.func
 
-        # curry- or functools.partial-like object?  Unpack and merge arguments
-        if (hasattr(func, 'func') and hasattr(func, 'args')
-                and hasattr(func, 'keywords')):
-            _kwargs = {}
-            if func.keywords:
-                _kwargs.update(func.keywords)
-            _kwargs.update(kwargs)
-            kwargs = _kwargs
-            args = func.args + args
-            func = func.func
-
-        if kwargs:
-            self.call = partial(func, *args, **kwargs)
-        else:
-            self.call = partial(func, *args)
-        self.__doc__ = func.__doc__
-        try:
-            self.func_name = self.func.func_name
-        except AttributeError:
-            pass
-
-    @property
-    def func(self):
-        return self.call.func
-
-    @property
-    def args(self):
-        return self.call.args
-
-    @property
-    def keywords(self):
-        return self.call.keywords
-
-    def __str__(self):
-        return str(self.func)
-
-    def __repr__(self):
-        return repr(self.func)
-
-    def __call__(self, *args, **kwargs):
-        try:
-            return self.call(*args, **kwargs)
-        except TypeError:
-            required_args = _num_required_args(self.func)
-
-            # If there was a genuine TypeError
-            if (required_args is not None and
-                    len(args) + len(self.args) >= required_args):
-                raise
-
-            return curry(self.call, *args, **kwargs)
-
-    # pickle protocol because functools.partial objects can't be pickled
-    def __getstate__(self):
-        return self.func, self.args, self.keywords
-
-    def __setstate__(self, state):
-        func, args, kwargs = state
-        self.__init__(func, *args, **(kwargs or {}))
+    required_args = _num_required_args(func)
+    if (required_args is not None and required_args - len(args) == 1
+            and not _may_have_kwargs(func)):
+        return partial(func, *args, **kwargs)
+    return Curry(func, *args, **kwargs)
 
 
 @curry
@@ -226,15 +262,8 @@ def memoize(func, cache=None):
     if cache is None:
         cache = {}
 
-    try:
-        spec = inspect.getargspec(func)
-        may_have_kwargs = bool(not spec or spec.keywords or spec.defaults)
-        # Is unary function (single arg, no variadic argument or keywords)?
-        is_unary = (spec and spec.varargs is None and not may_have_kwargs
-                    and len(spec.args) == 1)
-    except TypeError:
-        may_have_kwargs = True
-        is_unary = False
+    may_have_kwargs = _may_have_kwargs(func)
+    is_unary = not may_have_kwargs and _is_unary(func)
 
     def memof(*args, **kwargs):
         try:

--- a/toolz/functoolz/tests/test_core.py
+++ b/toolz/functoolz/tests/test_core.py
@@ -1,6 +1,6 @@
 from toolz.functoolz import (thread_first, thread_last, memoize, curry,
                              compose, pipe, complement, do)
-from toolz.functoolz.core import _num_required_args
+from toolz.functoolz.core import _num_required_args, Curry
 from operator import add, mul
 from toolz.utils import raises
 from functools import partial
@@ -218,9 +218,9 @@ def test_curry_is_idempotent():
 
     f = curry(foo, 1, c=2)
     g = curry(f)
-    assert isinstance(f, curry)
-    assert isinstance(g, curry)
-    assert not isinstance(f.func, curry)
+    assert isinstance(f, Curry)
+    assert isinstance(g, Curry)
+    assert not isinstance(g.func, Curry)
     assert not hasattr(g.func, 'func')
     # curry makes a new curry object, so everything is distinct but equal
     assert f is not g


### PR DESCRIPTION
`curry` instances always return other `curry` instance if the arguments are not fully applied; previously, they could sometimes return `functools.partial` instances.

The performance of calling `curry` instances is better than before, but still not as good as calling `partial`.  To achieve the performance of `partial`, use `curried_func.call`.

This PR addresses the idempotency issue from #147.  It does not, however, split `curry` into `class Curry/def curry` as discussed in #147 (or as indicated by the name of this branch).  I think `curry` performs just fine as a single class.
