### PR TITLE
Add a newline for correct formatting in docs

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -613,6 +613,7 @@ def pluck(ind, seqs, default=no_default):
     ``seqs`` should be sequence containing sequences or dicts.
 
     e.g.
+
     >>> data = [{'id': 1, 'name': 'Cheese'}, {'id': 2, 'name': 'Pies'}]
     >>> list(pluck('name', data))
     ['Cheese', 'Pies']


### PR DESCRIPTION
Now formatting of the pluck() code example is broken: http://toolz.readthedocs.org/en/latest/api.html#toolz.itertoolz.pluck
