### PR TITLE
`pip` is the python package installation tool.

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -2,11 +2,7 @@ Installation and Dependencies
 =============================
 
 Toolz is pure Python and so is easily installable by the standard
-dependency managers ``pip`` and ``easy_install``::
-
-    easy_install toolz
-
-or::
+dependency manager ``pip``::
 
     pip install toolz
 


### PR DESCRIPTION
`easy_install` doesn't do things like verify certificates and so shouldn't be used.
