### PR TITLE
Fixing typo in purity.rst

### DIFF
--- a/doc/source/purity.rst
+++ b/doc/source/purity.rst
@@ -58,7 +58,7 @@ Another problem occurs when we run this code in a different context:
 .. code::
 
     >>> data = [1, 2, 3]
-    >>> result = powers(L)
+    >>> result = powers(data)
     >>> print result
     [1, 8, 27]
 


### PR DESCRIPTION
The `L` argument should be `data`.
