### PR TITLE
Add `toolz.utils.consume` to efficiently consume an iterator

### DIFF
--- a/toolz/tests/test_utils.py
+++ b/toolz/tests/test_utils.py
@@ -1,6 +1,14 @@
-from toolz.utils import raises
+from toolz.utils import raises, consume
 
 
 def test_raises():
     assert raises(ZeroDivisionError, lambda: 1 / 0)
     assert not raises(ZeroDivisionError, lambda: 1)
+
+
+def test_consume():
+    data = [1, 2, 3, 4]
+    it = iter(data)
+    assert consume(it) is None
+    assert raises(StopIteration, lambda: next(it))
+    assert consume(data) is None

--- a/toolz/utils.py
+++ b/toolz/utils.py
@@ -1,3 +1,6 @@
+from collections import deque
+
+
 def raises(err, lamda):
     try:
         lamda()
@@ -7,3 +10,8 @@ def raises(err, lamda):
 
 
 no_default = '__no__default__'
+
+
+def consume(seq):
+    """ Efficiently consume an iterator"""
+    deque(seq, 0)


### PR DESCRIPTION
`consume` is a convenience function that efficiently consumes an iterator.  I find it useful for benchmarking, but I don't know if it's generally useful enough to be part of the main `toolz` API, which is why I put it in `toolz.utils`.  If other people think it is useful enough, we could move it to `toolz.itertoolz`.

The method used (`deque(seq, 0)`) is really fast.  The Cython implementation in `cytoolz` is even faster (and is what I really want)!
