### PR TITLE
Faster `remove` by using `itertools.filterfalse`, which was added to `compatibility`

### DIFF
--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -3,7 +3,7 @@ import sys
 PY3 = sys.version_info[0] > 2
 
 __all__ = ('PY3', 'map', 'filter', 'range', 'zip', 'reduce', 'zip_longest',
-           'iteritems', 'iterkeys', 'itervalues')
+           'iteritems', 'iterkeys', 'itervalues', 'filterfalse')
 
 if PY3:
     map = map
@@ -12,6 +12,7 @@ if PY3:
     zip = zip
     from functools import reduce
     from itertools import zip_longest
+    from itertools import filterfalse
     iteritems = operator.methodcaller('items')
     iterkeys = operator.methodcaller('keys')
     itervalues = operator.methodcaller('values')
@@ -20,6 +21,7 @@ else:
     reduce = reduce
     from itertools import imap as map
     from itertools import ifilter as filter
+    from itertools import ifilterfalse as filterfalse
     from itertools import izip as zip
     from itertools import izip_longest as zip_longest
     iteritems = operator.methodcaller('iteritems')

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -3,7 +3,7 @@ import heapq
 import collections
 import operator
 from functools import partial
-from toolz.compatibility import map, filter, zip, zip_longest
+from toolz.compatibility import map, filter, filterfalse, zip, zip_longest
 
 
 __all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
@@ -17,14 +17,14 @@ identity = lambda x: x
 
 
 def remove(predicate, seq):
-    """ Return those items of collection for which predicate(item) is true.
+    """ Return those items of sequence for which predicate(item) is False
 
     >>> def iseven(x):
     ...     return x % 2 == 0
     >>> list(remove(iseven, [1, 2, 3, 4]))
     [1, 3]
     """
-    return filter(lambda x: not predicate(x), seq)
+    return filterfalse(predicate, seq)
 
 
 def accumulate(binop, seq):


### PR DESCRIPTION
Also, a typo (it lied!) was fixed in the documentation of `remove`

By using `filterfalse`, we modify the behavior of `remove` when `None` is used as the predicate.  Previously, `remove(None, [0, 1, 2])` raised `TypeError`.  Now it returns `[0]` (i.e., all false-y values).  If we want the former, we can add a check for `None`.
