### PR TITLE
Faster unique, isdistinct, merge_sorted, and sliding_window.

### DIFF
--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -3,7 +3,7 @@ from toolz.utils import raises
 from functools import partial
 from toolz.itertoolz import (remove, groupby, merge_sorted,
                              concat, concatv, interleave, unique,
-                             identity, isiterable,
+                             isiterable,
                              mapcat, isdistinct, first, second,
                              nth, take, drop, interpose, get,
                              rest, last, cons, frequencies,
@@ -12,6 +12,10 @@ from toolz.itertoolz import (remove, groupby, merge_sorted,
                              partition_all, take_nth, pluck)
 from toolz.compatibility import range, filter
 from operator import add, mul
+
+
+def identity(x):
+    return x
 
 
 def iseven(x):
@@ -54,6 +58,7 @@ def test_merge_sorted():
     assert ''.join(merge_sorted('abc', 'abc', 'abc', key=ord)) == 'aaabbbccc'
     assert ''.join(merge_sorted('cba', 'cba', 'cba',
                                 key=lambda x: -ord(x))) == 'cccbbbaaa'
+    assert list(merge_sorted([1], [2, 3, 4], key=identity)) == [1, 2, 3, 4]
 
 
 def test_interleave():


### PR DESCRIPTION
The `key` keyword argument to `unique` was changed from `identity` to `None`.  This better matches API elsewhere, and lets us remove `identity` from being redefined in `itertoolz`, which always seemed a little weird.

Most of the speed improvements come from avoiding attribute resolution in frequently run code.  Attribute resolution (i.e., the "dot" operator) is probably more costly than one would expect.  Fortunately, there weren't many places to apply this optimization, so impact on code readability was minimal.

`unique` employs another optimization: branching by `key is None` outside the loop (thus requiring two loops).  While this violates the DRY principle (and, hence, I would prefer not to do it in general), this is only a few lines of code that remain side-by-side, and the performance increase is worth it.

`merge_sorted` is now optimized when only a single iterable remains.  This makes it _so_ much faster while in this condition.
