### PR TITLE
Faster groupby!

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -3,7 +3,8 @@ import heapq
 import collections
 import operator
 from functools import partial
-from toolz.compatibility import map, filter, filterfalse, zip, zip_longest
+from toolz.compatibility import (map, filter, filterfalse, zip, zip_longest,
+                                 iteritems)
 
 
 __all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
@@ -68,29 +69,12 @@ def groupby(func, seq):
     See Also:
         countby
     """
-    # The commented code below shows what is probably the fastest
-    # "pythonic" implementation of `groupby`:
-    #
-    # d = collections.defaultdict(list)
-    # for item in seq:
-    #     d[func(item)].append(item)
-    # return dict(d)
-
-    rv = {}
-    fastdict = {}
+    d = collections.defaultdict(lambda: [].append)
     for item in seq:
-        key = func(item)
-        if key in fastdict:
-            # Optimal asymptotic performance
-            fastdict[key](item)  # append item to list
-        elif key not in rv:
-            # Fast initialization of groups
-            rv[key] = [item]
-        else:
-            # Add `list.append` to `fastdict` to avoid attribute resolution
-            # overhead.  This improves asymptotic speed as groups get larger.
-            val = fastdict[key] = rv[key].append
-            val(item)
+        d[func(item)](item)
+    rv = {}
+    for k, v in iteritems(d):
+        rv[k] = v.__self__
     return rv
 
 


### PR DESCRIPTION
Issue #178 impressed upon me just how costly attribute resolution can be.  In this case, `groupby` was made faster by avoiding resolving the attribute `list.append`.

This implementation is also more memory efficient than the current version that uses a `defaultdict` that gets cast to a `dict`.  While casting a defaultdict `d` to a dict as `dict(d)` is fast, it is still a fast _copy_.

Honorable mention goes to the following implementation:

``` python
def groupby_alt(func, seq):
    d = collections.defaultdict(lambda: [].append)
    for item in seq:
        d[func(item)](item)
    rv = {}
    for k, v in iteritems(d):
        rv[k] = v.__self__
    return rv
```

This alternative implementation can at times be _very_ impressive.  You should play with it!
