### PR TITLE
add intersect_sorted

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -10,7 +10,8 @@ __all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
            'unique', 'isiterable', 'isdistinct', 'take', 'drop', 'take_nth',
            'first', 'second', 'nth', 'last', 'get', 'concat', 'concatv',
            'mapcat', 'cons', 'interpose', 'frequencies', 'reduceby', 'iterate',
-           'sliding_window', 'partition', 'partition_all', 'count', 'pluck')
+           'sliding_window', 'partition', 'partition_all', 'count', 'pluck',
+           'intersect_sorted')
 
 
 identity = lambda x: x
@@ -72,6 +73,25 @@ def groupby(func, seq):
     for item in seq:
         d[func(item)].append(item)
     return dict(d)
+
+
+def intersect_sorted(*seqs):
+    """ Intersection of a collection of sorted iterables.
+
+    Generates (once) each item that occurs in each of the iterables *seqs.
+
+    >>> list(intersect_sorted([1, 1, 3, 5, 5], [1, 2, 3, 4, 5], [3, 4, 5]))
+    [3, 5]
+    """
+    from itertools import groupby as itgroupby
+
+    # Remove repeated elements from each iterable to make length check work.
+    n = len(seqs)
+    seqs = ((x for (x, _) in itgroupby(it)) for it in seqs)
+
+    for x, group in itgroupby(merge_sorted(*seqs)):
+        if sum(1 for _ in group) == n:
+            yield x
 
 
 def merge_sorted(*seqs, **kwargs):

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -3,7 +3,7 @@ from toolz.utils import raises
 from functools import partial
 from toolz.itertoolz import (remove, groupby, merge_sorted,
                              concat, concatv, interleave, unique,
-                             identity, isiterable,
+                             identity, isiterable, intersect_sorted,
                              mapcat, isdistinct, first, second,
                              nth, take, drop, interpose, get,
                              rest, last, cons, frequencies,
@@ -54,6 +54,14 @@ def test_merge_sorted():
     assert ''.join(merge_sorted('abc', 'abc', 'abc', key=ord)) == 'aaabbbccc'
     assert ''.join(merge_sorted('cba', 'cba', 'cba',
                                 key=lambda x: -ord(x))) == 'cccbbbaaa'
+
+
+def test_intersect_sorted():
+    assert list(intersect_sorted([1, 2, 3], [1, 2, 3])) == [1, 2, 3]
+    assert list(intersect_sorted([1, 3, 5], [2, 4, 6])) == []
+    assert list(intersect_sorted('aaab', 'bbbc', 'bc')) == ['b']
+
+    assert list(intersect_sorted([1, 1, 2, 2, 3, 4, 4, 4])) == [1, 2, 3, 4]
 
 
 def test_interleave():


### PR DESCRIPTION
Here's a utility function that sometimes comes in handy: `intersect_sorted` computes the intersection of multiple sorted sequences.

There's no `key` argument as I didn't have a clear intuition as to how that should affect the behavior.
