### PR TITLE
`get` and `pluck` on lists of length 1

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -648,9 +648,8 @@ def pluck(ind, seqs, default=no_default):
         map
     """
     if default is no_default:
-        if isinstance(ind, list):
-            return map(operator.itemgetter(*ind), seqs)
-        return map(operator.itemgetter(ind), seqs)
+        get = getter(ind)
+        return map(get, seqs)
     elif isinstance(ind, list):
         return (tuple(_get(item, seq, default) for item in ind)
                 for seq in seqs)

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -266,6 +266,7 @@ def test_pluck():
     assert list(pluck('id', data)) == [1, 2]
     assert list(pluck('price', data, None)) == [None, 1]
     assert list(pluck(['id', 'name'], data)) == [(1, 'cheese'), (2, 'pies')]
+    assert list(pluck(['name'], data)) == [('cheese',), ('pies',)]
     assert list(pluck(['price', 'other'], data, None)) == [(None, None),
                                                            (1, None)]
 


### PR DESCRIPTION
This used to provide a wrong result.
