### PR TITLE
Extend dicttoolz to support objects

### DIFF
--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -230,10 +230,7 @@ def get_in(keys, coll, default=None, no_default=False):
         operator.getitem
     """
     def get(d, key):
-        if hasattr(d, '__getitem__'):
-            return d[key]
-        else:
-            return getattr(d, key)
+        return d[key] if hasattr(d, '__getitem__') else getattr(d, key)
 
     try:
         return reduce(get, keys, coll)


### PR DESCRIPTION
This pull request explores extending dicttoolz functions assoc, update_in, and get_in to support objects.  I haven't brought in the tests from objtoolz yet -- wanted first of all to gauge interest.  Happy to consider alternative approaches.
