### PR TITLE
Add itertoolz.identical to test if sequences are identical element-wise

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -20,6 +20,7 @@ Itertoolz
    frequencies
    get
    groupby
+   identical
    interleave
    interpose
    isdistinct

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -12,7 +12,7 @@ __all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
            'first', 'second', 'nth', 'last', 'get', 'concat', 'concatv',
            'mapcat', 'cons', 'interpose', 'frequencies', 'reduceby', 'iterate',
            'sliding_window', 'partition', 'partition_all', 'count', 'pluck',
-           'join')
+           'join', 'identical')
 
 
 def remove(predicate, seq):
@@ -772,3 +772,24 @@ def join(leftkey, leftseq, rightkey, rightseq,
             if key not in seen_keys:
                 for match in matches:
                     yield (match, right_default)
+
+
+def identical(*seqs):
+    """ Are sequences identical element-wise?
+
+    >>> identical([1, 2, 3], (1, 2, 3))
+    True
+
+    >>> identical([1, 2, 3], [1, 2])
+    False
+
+    This lazily evaluates the sequences and stops as soon as the result
+    is determined.
+    """
+    N = len(seqs)
+    if N < 2:
+        return True
+    for items in zip_longest(*seqs, fillvalue=object()):
+        if items.count(items[0]) != N:
+            return False
+    return True

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -10,7 +10,8 @@ from toolz.itertoolz import (remove, groupby, merge_sorted,
                              rest, last, cons, frequencies,
                              reduceby, iterate, accumulate,
                              sliding_window, count, partition,
-                             partition_all, take_nth, pluck, join)
+                             partition_all, take_nth, pluck, join,
+                             identical)
 from toolz.compatibility import range, filter
 from operator import add, mul
 
@@ -379,3 +380,15 @@ def test_outer_join():
     expected = set([(2, 2), (1, None), (None, 3)])
 
     assert result == expected
+
+
+def test_identical():
+    assert identical([1, 2, 3], [1, 2, 3]) is True
+    assert identical([1, 2, 3], (1, 2, 3), iter([1, 2, 3])) is True
+    assert identical([1, 2, 3], [1, 2]) is False
+    assert identical([1, 2], [1, 2, 3]) is False
+    assert identical([1, 2], [1, 2], [1, 2]) is True
+    assert identical([[], {}], [[], {}]) is True
+    assert identical([1, 2]) is True
+    assert identical([1, None], [1]) is False
+    assert identical() is True  # vacuous truth


### PR DESCRIPTION
This problem is actually more tricky--and coming up with a good implementation more challenging--then you might initially expect.  The current implementation was not my first attempt.

Typical application of `identical` is for consistency checks.  Development workflows often have the following progression: (1) make something that works, and (2) make it better.  "Better" can mean more maintainable, more features (that shouldn't change current behavior), different algorithms/techniques/dependencies/etc, or better performance.  Similarly, sometimes data gets ported to a different format (such as a new database), and one often wants to verify the data and processing tools are equivalent to the original.  Unit tests should typically *help* with this, but real data is often messy and has intricacies you may not think to test.  Also, many other developers are paranoid (myself especially), and want to perform consistency checks to verify *exact* behavior in as many (reasonable) ways as possible.