### PR TITLE
Add `itertoolz.diff` to yield elements that differ between sequences.

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -15,6 +15,7 @@ Itertoolz
    concatv
    cons
    count
+   diff
    drop
    first
    frequencies

--- a/doc/source/tips-and-tricks.rst
+++ b/doc/source/tips-and-tricks.rst
@@ -102,3 +102,25 @@ a few of these recipes.
      'location': 'Oakland',
      'name': 'Matthew',
      'person_id': 2}]
+
+* .. function:: areidentical(\*seqs)
+
+  Determine if sequences are identical element-wise.
+  This lazily evaluates the sequences and stops as soon as the result
+  is determined.
+
+  ::
+
+    from toolz import diff
+
+    def areidentical(*seqs):
+        return not any(diff(*seqs, default=object()))
+
+
+  Example:
+
+   >>> areidentical([1, 2, 3], (1, 2, 3))
+   True
+
+   >>> areidentical([1, 2, 3], [1, 2])
+   False

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -788,18 +788,8 @@ def diff(*seqs, **kwargs):
     A ``key`` function may also be applied to each item to use during
     comparisons:
 
-    >>> data1 = [{'cost': 1, 'currency': 'dollar'},
-    ...          {'cost': 2, 'currency': 'dollar'}]
-
-    >>> data2 = [{'cost': 100, 'currency': 'yen'},
-    ...          {'cost': 300, 'currency': 'yen'}]
-
-    >>> conversions = {'dollar': 1, 'yen': 0.01}
-    >>> def indollars(item):
-    ...     return conversions[item['currency']] * item['cost']
-
-    >>> list(diff(data1, data2, key=indollars))  # doctest:+SKIP
-    [({'cost': 2, 'currency': 'dollar'}, {'cost': 300, 'currency': 'yen'})]
+    >>> list(diff(['apples', 'bananas'], ['Apples', 'Oranges'], key=str.lower))
+    [('bananas', 'Oranges')]
 
     """
     N = len(seqs)

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -833,11 +833,13 @@ def diff(*seqs, **kwargs):
 
     >>> list(diff(['apples', 'bananas'], ['Apples', 'Oranges'], key=str.lower))
     [('bananas', 'Oranges')]
-
     """
     N = len(seqs)
+    if N == 1 and isinstance(seqs[0], list):
+        seqs = seqs[0]
+        N = len(seqs)
     if N < 2:
-        raise StopIteration()
+        raise TypeError('Too few sequences given (min 2 required)')
     default = kwargs.get('default', no_default)
     if default is no_default:
         iters = zip(*seqs)

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -383,6 +383,8 @@ def test_outer_join():
 
 
 def test_diff():
+    assert list(diff()) == []
+    assert list(diff([1, 2])) == []
     assert list(diff([1, 2], (1, 2), iter([1, 2]))) == []
     assert list(diff([1, 2, 3], (1, 10, 3), iter([1, 2, 10]))) == [
         (2, 10, 2), (3, 3, 10)]

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -407,13 +407,20 @@ def test_outer_join():
 
 
 def test_diff():
-    assert list(diff()) == []
-    assert list(diff([1, 2])) == []
+    assert raises(TypeError, lambda: list(diff()))
+    assert raises(TypeError, lambda: list(diff([1, 2])))
+    assert raises(TypeError, lambda: list(diff([1, 2], 3)))
     assert list(diff([1, 2], (1, 2), iter([1, 2]))) == []
     assert list(diff([1, 2, 3], (1, 10, 3), iter([1, 2, 10]))) == [
         (2, 10, 2), (3, 3, 10)]
     assert list(diff([1, 2], [10])) == [(1, 10)]
     assert list(diff([1, 2], [10], default=None)) == [(1, 10), (2, None)]
+    # non-variadic usage
+    assert raises(TypeError, lambda: list(diff([])))
+    assert raises(TypeError, lambda: list(diff([[]])))
+    assert raises(TypeError, lambda: list(diff([[1, 2]])))
+    assert raises(TypeError, lambda: list(diff([[1, 2], 3])))
+    assert list(diff([(1, 2), (1, 3)])) == [(2, 3)]
 
     data1 = [{'cost': 1, 'currency': 'dollar'},
              {'cost': 2, 'currency': 'dollar'}]

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -10,7 +10,8 @@ from toolz.itertoolz import (remove, groupby, merge_sorted,
                              rest, last, cons, frequencies,
                              reduceby, iterate, accumulate,
                              sliding_window, count, partition,
-                             partition_all, take_nth, pluck, join)
+                             partition_all, take_nth, pluck, join,
+                             diff)
 from toolz.compatibility import range, filter
 from operator import add, mul
 
@@ -379,3 +380,25 @@ def test_outer_join():
     expected = set([(2, 2), (1, None), (None, 3)])
 
     assert result == expected
+
+
+def test_diff():
+    assert list(diff([1, 2], (1, 2), iter([1, 2]))) == []
+    assert list(diff([1, 2, 3], (1, 10, 3), iter([1, 2, 10]))) == [
+        (2, 10, 2), (3, 3, 10)]
+    assert list(diff([1, 2], [10])) == [(1, 10)]
+    assert list(diff([1, 2], [10], default=None)) == [(1, 10), (2, None)]
+
+    data1 = [{'cost': 1, 'currency': 'dollar'},
+             {'cost': 2, 'currency': 'dollar'}]
+
+    data2 = [{'cost': 100, 'currency': 'yen'},
+             {'cost': 300, 'currency': 'yen'}]
+
+    conversions = {'dollar': 1, 'yen': 0.01}
+
+    def indollars(item):
+        return conversions[item['currency']] * item['cost']
+
+    list(diff(data1, data2, key=indollars)) == [
+        ({'cost': 2, 'currency': 'dollar'}, {'cost': 300, 'currency': 'yen'})]


### PR DESCRIPTION
Also, add `areidentical` to "Tips and Tricks" section of documentation.  `areidentical` *uses* `diff`.

This was first discussed in #200