### PR TITLE
Consume

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -14,6 +14,7 @@ Itertoolz
    concat
    concatv
    cons
+   consume
    count
    drop
    first

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -12,7 +12,7 @@ __all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
            'first', 'second', 'nth', 'last', 'get', 'concat', 'concatv',
            'mapcat', 'cons', 'interpose', 'frequencies', 'reduceby', 'iterate',
            'sliding_window', 'partition', 'partition_all', 'count', 'pluck',
-           'join')
+           'join', 'consume')
 
 
 def remove(predicate, seq):
@@ -776,3 +776,28 @@ def join(leftkey, leftseq, rightkey, rightseq,
             if key not in seen_keys:
                 for match in matches:
                     yield (match, right_default)
+
+
+def consume(iterator, n=None):
+    """ Efficiently consume an iterator without returning anything.
+
+    If `n` is specified and not `None`, consume `n` items from the iterator.
+
+    The iterator is advanced in-place. There is no return value.
+
+    >>> a = iter([0, 1, 2, 3, 4, 5])
+    >>> consume(a)
+    >>> list(a)
+    []
+
+    >>> a = iter([0, 1, 2, 3, 4, 5])
+    >>> consume(a, 3)
+    >>> list(a)
+    [3, 4, 5]
+    """
+    if n is None:
+        # feed the entire iterator into a zero-length deque
+        collections.deque(iterator, maxlen=0)
+    else:
+        # advance to the empty slice starting at position n
+        next(itertools.islice(iterator, n, n), None)

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -10,7 +10,7 @@ from toolz.itertoolz import (remove, groupby, merge_sorted,
                              rest, last, cons, frequencies,
                              reduceby, iterate, accumulate,
                              sliding_window, count, partition,
-                             partition_all, take_nth, pluck, join)
+                             partition_all, take_nth, pluck, join, consume)
 from toolz.compatibility import range, filter
 from operator import add, mul
 
@@ -386,3 +386,22 @@ def test_outer_join():
     expected = set([(2, 2), (1, None), (None, 3)])
 
     assert result == expected
+
+
+def test_consume():
+    testlist = [0, 1, 2, 3, 4, 5]
+
+    testiter1 = iter(testlist)
+    testiter2 = iter(testlist)
+    testiter3 = iter(testlist)
+    testiter4 = iter(testlist)
+
+    consume(testiter1)
+    consume(testiter2, n=None)
+    consume(testiter3, 3)
+    consume(testiter4, n=7)
+
+    assert list(testiter1) == []
+    assert list(testiter2) == []
+    assert list(testiter3) == [3, 4, 5]
+    assert list(testiter4) == []


### PR DESCRIPTION
As discussed in #208, implements `itertoolz.consume`.

I also adapted matplotlib's .gitignore, which deals with a lot of additional file types.
