### PR TITLE
add dissoc function to dictoolz

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -71,6 +71,7 @@ Dicttoolz
 
 .. autosummary::
    assoc
+   dissoc
    get_in
    keyfilter
    keymap

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -3,7 +3,7 @@ from toolz.compatibility import (map, zip, iteritems, iterkeys, itervalues,
                                  reduce)
 
 __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'valfilter', 'keyfilter',
-           'assoc', 'update_in', 'get_in')
+           'assoc', 'dissoc', 'update_in', 'get_in')
 
 
 def merge(*dicts):
@@ -133,6 +133,21 @@ def assoc(d, key, value):
     {'x': 1, 'y': 3}
     """
     return merge(d, {key: value})
+
+
+def dissoc(d, key):
+    """
+    Return a new dict with the given key removed.
+
+    New dict has d[key] deleted.
+    Does not modify the initial dictionary.
+
+    >>> dissoc({'x': 1, 'y': 2}, 'y')
+    {'x': 1}
+    """
+    d2 = d.copy()
+    del d2[key]
+    return d2
 
 
 def update_in(d, keys, func, default=None):

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -1,6 +1,6 @@
 from toolz.utils import raises
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
-                             assoc, keyfilter, valfilter)
+                             assoc, dissoc, keyfilter, valfilter)
 
 
 inc = lambda x: x + 1
@@ -62,6 +62,19 @@ def test_assoc():
     oldd = d
     assoc(d, 'x', 2)
     assert d is oldd
+
+
+def test_dissoc():
+    assert dissoc({"a": 1}, "a") == {}
+    assert dissoc({"a": 1, "b": 2}, "a") == {"b": 2}
+    assert dissoc({"a": 1, "b": 2}, "b") == {"a": 1}
+
+    # Verify immutability:
+    d = {'x': 1}
+    oldd = d
+    d2 = dissoc(d, 'x')
+    assert d is oldd
+    assert d2 is not oldd
 
 
 def test_update_in():


### PR DESCRIPTION
This adds the inverse operation of `dictoolz.assoc`, `dictoolz.dissoc`.  It returns a copy of the dictionary with the given key removed, as discussed in #209.
