### PR TITLE
Remove positional arg "func" from curry.__init__

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,3 +19,5 @@ José Ricardo                                    [@josericardo](https://github.c
 Tom Prince                                      [@tomprince](https://github.com/tomprince)
 
 Bart van Merriënboer                            [@bartvm](https://github.com/bartvm)
+
+Nikolaos-Digenis Karagiannis                    [@digenis](https://github.com/digenis/)

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -152,7 +152,10 @@ class curry(object):
         toolz.curried - namespace of curried functions
                         http://toolz.readthedocs.org/en/latest/curry.html
     """
-    def __init__(self, func, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
+        if not args:
+            raise TypeError('__init__() takes at least 2 arguments (1 given)')
+        func, args = args[0], args[1:]
         if not callable(func):
             raise TypeError("Input must be callable")
 

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -187,6 +187,14 @@ def test_curry_kwargs():
     assert cg(0) == 2  # pass "a" as arg, not kwarg
     assert raises(TypeError, lambda: cg(1, 2))  # pass "b" as arg AND kwarg
 
+    def h(x, func=int):
+        return func(x)
+
+    # __init__ must not pick func as positional arg
+    assert curry(h)(0.0) == 0
+    assert curry(h)(func=str)(0.0) == '0.0'
+    assert curry(h, func=str)(0.0) == '0.0'
+
 
 def test_curry_passes_errors():
     @curry

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -1,3 +1,6 @@
+import platform
+
+
 from toolz.functoolz import (thread_first, thread_last, memoize, curry,
                              compose, pipe, complement, do, juxt)
 from toolz.functoolz import _num_required_args
@@ -190,10 +193,12 @@ def test_curry_kwargs():
     def h(x, func=int):
         return func(x)
 
-    # __init__ must not pick func as positional arg
-    assert curry(h)(0.0) == 0
-    assert curry(h)(func=str)(0.0) == '0.0'
-    assert curry(h, func=str)(0.0) == '0.0'
+    if platform.python_implementation() != 'PyPy'\
+            or platform.python_version_tuple()[0] != '3':  # Bug on PyPy3<2.5
+        # __init__ must not pick func as positional arg
+        assert curry(h)(0.0) == 0
+        assert curry(h)(func=str)(0.0) == '0.0'
+        assert curry(h, func=str)(0.0) == '0.0'
 
 
 def test_curry_passes_errors():

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -161,6 +161,7 @@ def test_curry_simple():
     cmap = curry(map)
     assert list(cmap(inc)([1, 2, 3])) == [2, 3, 4]
 
+    assert raises(TypeError, lambda: curry())
     assert raises(TypeError, lambda: curry({1: 2}))
 
 


### PR DESCRIPTION
conflicted with kwargs['func']

example.py:
```python
from toolz import curry
@curry
def foo(x, y, func=int, bar=str):
    return str(func(x*y))
foo(bar=float)(4.2, 3.8, func=round)
foo(func=int)(4.2, 3.8, bar=str)
```
The last line would throw ```TypeError: __init__() got multiple values for keyword argument 'func'```
because ```curry.__init__(self, func, *args, **kwargs)``` names its first positional argument "func"
This effectively prevented creating a curry object with such a kwarg.
I didn't find other functions with the same problem.

```python
> /home/digenis/src/toolz/toolz/example.py(1)<module>()
-> from toolz import curry
(pdb) c
Traceback (most recent call last):
 ...
  File "/home/digenis/src/toolz/toolz/functoolz.py", line 224, in __call__
    return curry(self._partial, *args, **kwargs)
TypeError: __init__() got multiple values for keyword argument 'func'
...
> /home/digenis/src/toolz/toolz/functoolz.py(224)__call__()
-> return curry(self._partial, *args, **kwargs)
(pdb) self._partial  # __init__ will receive this as the positional argument "func"
<functools.partial object at 0x7f16874ee0a8>
(pdb) pp args
()
(pdb) pp kwargs  # but it will also receive a kwarg named "func"
{'func': <type 'int'>}


Post mortem debugger finished. The example.py will be restarted
...
```
I abbreviated some line ranges with "..."
