### PR TITLE
`curry` can work on class methods by using the `__get__` descriptor protocol

### DIFF
--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -223,6 +223,9 @@ class curry(object):
 
         return curry(self._partial, *args, **kwargs)
 
+    def __get__(self, instance, owner):
+        return curry(self, instance)
+
     # pickle protocol because functools.partial objects can't be pickled
     def __getstate__(self):
         # dictoolz.keyfilter, I miss you!

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -224,7 +224,12 @@ class curry(object):
         return curry(self._partial, *args, **kwargs)
 
     def __get__(self, instance, owner):
-        return curry(self, instance)
+        selfcurry = self
+        def curried_method(self, *args, **kwargs):
+            return selfcurry(self, *args, **kwargs)
+        curried_method.__name__ = self.__name__
+        curried_method.__doc__ = self.__doc__
+        return curried_method.__get__(instance, owner)
 
     # pickle protocol because functools.partial objects can't be pickled
     def __getstate__(self):

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -224,12 +224,9 @@ class curry(object):
         return curry(self._partial, *args, **kwargs)
 
     def __get__(self, instance, owner):
-        selfcurry = self
-        def curried_method(self, *args, **kwargs):
-            return selfcurry(self, *args, **kwargs)
-        curried_method.__name__ = self.__name__
-        curried_method.__doc__ = self.__doc__
-        return curried_method.__get__(instance, owner)
+        if instance is None:
+            return self
+        return curry(self, instance)
 
     # pickle protocol because functools.partial objects can't be pickled
     def __getstate__(self):

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -4,7 +4,7 @@ from toolz.functoolz import _num_required_args
 from operator import add, mul, itemgetter
 from toolz.utils import raises
 from functools import partial
-from toolz.compatibility import reduce
+from toolz.compatibility import reduce, PY3
 
 
 def iseven(x):
@@ -337,8 +337,12 @@ def test_curry_on_classmethods():
     a = A(100)
     assert a.addmethod(3, 4) == 107
     assert a.addmethod(3)(4) == 107
-    assert raises(AttributeError, lambda: A.addmethod(3, 4))
-    assert raises(AttributeError, lambda: A.addmethod(3)(4))
+    if PY3:
+        assert A.addmethod(a, 3, 4) == 107
+        assert A.addmethod(a)(3)(4) == 107
+    else:
+        assert raises(TypeError, lambda: A.addmethod(3, 4))
+        assert raises(TypeError, lambda: A.addmethod(3)(4))
 
     assert a.addclass(3, 4) == 17
     assert a.addclass(3)(4) == 17
@@ -349,6 +353,54 @@ def test_curry_on_classmethods():
     assert a.addstatic(3)(4) == 7
     assert A.addstatic(3, 4) == 7
     assert A.addstatic(3)(4) == 7
+
+
+def test_memoize_on_classmethods():
+    class A(object):
+        BASE = 10
+        HASH = 10
+
+        def __init__(self, base):
+            self.BASE = base
+
+        @memoize
+        def addmethod(self, x, y):
+            return self.BASE + x + y
+
+        @classmethod
+        @memoize
+        def addclass(cls, x, y):
+            return cls.BASE + x + y
+
+        @staticmethod
+        @memoize
+        def addstatic(x, y):
+            return x + y
+
+        def __hash__(self):
+            return self.HASH
+
+    a = A(100)
+    assert a.addmethod(3, 4) == 107
+    if PY3:
+        assert A.addmethod(a, 3, 4) == 107
+    else:
+        assert raises(TypeError, lambda: A.addmethod(3, 4))
+
+    a.BASE = 200
+    assert a.addmethod(3, 4) == 107
+    a.HASH = 200
+    assert a.addmethod(3, 4) == 207
+
+    assert a.addclass(3, 4) == 17
+    assert A.addclass(3, 4) == 17
+    A.BASE = 20
+    assert A.addclass(3, 4) == 17
+    A.HASH = 20  # hashing of class is handled by metaclass
+    assert A.addclass(3, 4) == 17  # hence, != 27
+
+    assert a.addstatic(3, 4) == 7
+    assert A.addstatic(3, 4) == 7
 
 
 def test__num_required_args():

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -354,6 +354,7 @@ def test_curry_on_classmethods():
     assert isinstance(a.addmethod, curry)
     assert isinstance(A.addmethod, curry)
 
+
 def test_memoize_on_classmethods():
     class A(object):
         BASE = 10

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -313,6 +313,44 @@ def test_curry_doesnot_transmogrify():
     assert cf(y=1)(y=2)(y=3)(1) == f(1, 3)
 
 
+def test_curry_on_classmethods():
+    class A(object):
+        BASE = 10
+
+        def __init__(self, base):
+            self.BASE = base
+
+        @curry
+        def addmethod(self, x, y):
+            return self.BASE + x + y
+
+        @classmethod
+        @curry
+        def addclass(cls, x, y):
+            return cls.BASE + x + y
+
+        @staticmethod
+        @curry
+        def addstatic(x, y):
+            return x + y
+
+    a = A(100)
+    assert a.addmethod(3, 4) == 107
+    assert a.addmethod(3)(4) == 107
+    assert raises(AttributeError, lambda: A.addmethod(3, 4))
+    assert raises(AttributeError, lambda: A.addmethod(3)(4))
+
+    assert a.addclass(3, 4) == 17
+    assert a.addclass(3)(4) == 17
+    assert A.addclass(3, 4) == 17
+    assert A.addclass(3)(4) == 17
+
+    assert a.addstatic(3, 4) == 7
+    assert a.addstatic(3)(4) == 7
+    assert A.addstatic(3, 4) == 7
+    assert A.addstatic(3)(4) == 7
+
+
 def test__num_required_args():
     assert _num_required_args(map) != 0
     assert _num_required_args(lambda x: x) == 1

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -337,12 +337,8 @@ def test_curry_on_classmethods():
     a = A(100)
     assert a.addmethod(3, 4) == 107
     assert a.addmethod(3)(4) == 107
-    if PY3:
-        assert A.addmethod(a, 3, 4) == 107
-        assert A.addmethod(a)(3)(4) == 107
-    else:
-        assert raises(TypeError, lambda: A.addmethod(3, 4))
-        assert raises(TypeError, lambda: A.addmethod(3)(4))
+    assert A.addmethod(a, 3, 4) == 107
+    assert A.addmethod(a)(3)(4) == 107
 
     assert a.addclass(3, 4) == 17
     assert a.addclass(3)(4) == 17
@@ -354,6 +350,9 @@ def test_curry_on_classmethods():
     assert A.addstatic(3, 4) == 7
     assert A.addstatic(3)(4) == 7
 
+    # we want this to be of type curry
+    assert isinstance(a.addmethod, curry)
+    assert isinstance(A.addmethod, curry)
 
 def test_memoize_on_classmethods():
     class A(object):
@@ -382,10 +381,7 @@ def test_memoize_on_classmethods():
 
     a = A(100)
     assert a.addmethod(3, 4) == 107
-    if PY3:
-        assert A.addmethod(a, 3, 4) == 107
-    else:
-        assert raises(TypeError, lambda: A.addmethod(3, 4))
+    assert A.addmethod(a, 3, 4) == 107
 
     a.BASE = 200
     assert a.addmethod(3, 4) == 107


### PR DESCRIPTION
Tests also include `@classmethod` and `@staticmethod`, which currently must come after `@curry`.

This addresses issue #219 by @alanhdu.