### PR TITLE
Define Compose.__name__

### DIFF
--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -378,6 +378,10 @@ class Compose(object):
     def __setstate__(self, state):
         self.funcs = tuple(state)
 
+    @property
+    def __name__(self):
+        return '_o_'.join([fn.__name__ for fn in self.funcs])
+
 
 def compose(*funcs):
     """ Compose functions to operate in series.

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -336,6 +336,11 @@ def test_compose():
     assert compose(str, inc, f)(1, 2, c=3) == '10'
 
 
+def test_compose__name__():
+    assert 'double' in compose(double, inc).__name__
+    assert 'inc' in compose(double, inc).__name__
+
+
 def test_pipe():
     assert pipe(1, inc) == 2
     assert pipe(1, inc, inc) == 3


### PR DESCRIPTION
Should composed functions have a `__name__` attribute?

```Python
In [1]: def add(x, y):
    return x + y
   ...: 

In [2]: def inc(x):
    return x + 1
   ...: 

In [3]: from toolz import compose

In [4]: f = compose(inc, add)

In [5]: f.__name__
Out[5]: 'inc_o_add'
```

If so how should we define that name?  here I join with `_o_`.  Suggestions welcome.