### PR TITLE
Smarter wrapper behavior in functoolz.curry and functoolz.memoize

### DIFF
--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -1,5 +1,8 @@
 import operator
 import sys
+
+from functools import partial, WRAPPER_ASSIGNMENTS, WRAPPER_UPDATES
+
 PY3 = sys.version_info[0] > 2
 
 __all__ = ('PY3', 'map', 'filter', 'range', 'zip', 'reduce', 'zip_longest',
@@ -27,3 +30,90 @@ else:
     iteritems = operator.methodcaller('iteritems')
     iterkeys = operator.methodcaller('iterkeys')
     itervalues = operator.methodcaller('itervalues')
+
+
+# backport of Python 3.4 update_wrapper which has
+# much smarter behavior than other versions
+def update_wrapper(wrapper,
+                   wrapped,
+                   assigned=WRAPPER_ASSIGNMENTS,
+                   updated=WRAPPER_UPDATES):
+
+    """Makes wrapper appear as the wrapped callable.
+
+    Backport of Python3.4's functools.update_wrapper. This version is
+    more intelligent than what's found in Python 2 as it uses a
+    try/except/else block when moving attributes rather than just
+    charitably assuming the attributes are present.
+
+    It also backports Python 3's `__wrapped__` attribute as well
+    to give access to the original callable.
+
+    WARNING: This function modifies the wrapper function.
+
+    More useful for class based decorator than closure based decorators.
+
+    >>> class Decorator(object):
+    ...     def __init__(self, f):
+    ...         update_wrapper(self, f)
+    ...         self._f = f
+    ...     def __call__(self, *a, **k):
+    ...         return self._f(*a, **k)
+
+    >>> @Decorator
+    ... def add(a, b):
+    ...     "a doc string"
+    ...     return a + b
+
+    >>> print(add.__name__)
+    add
+    >>> print(add.__doc__)
+    a doc string
+    """
+
+    for attr in assigned:
+        try:
+            value = getattr(wrapped, attr)
+        except AttributeError:
+            pass
+        else:
+            setattr(wrapper, attr, value)
+
+    for attr in updated:
+        getattr(wrapper, attr).update(getattr(wrapped, attr, {}))
+
+    # store original callable last so it's not accidentally copied over
+    wrapper.__wrapped__ = wrapped
+
+    # return wrapper for use as a decorator
+    return wrapper
+
+
+def wraps(wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES):
+    """Decorator form of updated version of update_wrapper.
+
+    This is very useful for writing closure based decorators
+    rather than using update_wrapper manually on the closure.
+
+    WARNING: This function modifies what it's applied to.
+
+    >>> def decorator(f):
+    ...     @wraps(f)
+    ...     def wrapper(*a, **k):
+    ...         return f(*a, **k)
+    ...     return wrapper
+
+    >>> @decorator
+    ... def add(a, b):
+    ...     "a doc string"
+    ...     return a+b
+
+    >>> print(add.__name__)
+    add
+
+    >>> print(add.__doc__)
+    a doc string
+    """
+    # return partial to use as a decorator
+    return partial(update_wrapper, wrapped=wrapped,  # noqa
+           assigned=assigned, updated=updated)  # noqa

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -175,9 +175,9 @@ class curry(object):
 
         self.__name__ = getattr(func, '__name__', '<curried>')
         self.__doc__ = getattr(func, '__doc__', '<curry>')
-        self.__module__ = getattr(func, '__module__', '')
+        self.__module__ = getattr(func, '__module__', 'toolz.functoolz')
         # checking explicitly against PY3 fails for pypy3 and >3,3
-        if hasattr(func, '__qualname__') and hasattr(func, '__annotations__'):
+        if hasattr(func, '__qualname__') and hasattr(func, '__annotations__'): # pragma: no cover
             self.__qualname__ = getattr(func, '__qualname__', '')
             self.__annotations__ = getattr(func, '__annotations__', {})
 
@@ -357,9 +357,9 @@ def memoize(func, cache=None, key=None):
 
     memof.__doc__ = getattr(func, '__doc__', None)
     memof.__name__ = getattr(func, '__name__', '<memoized>')
-    memof.__module__ = getattr(func, '__module__', '')
+    memof.__module__ = getattr(func, '__module__', 'toolz.functoolz')
     # checking explicitly against PY3 fails for pypy3 and >3.3
-    if hasattr(func, '__qualname__') and hasattr(func, '__annotations__'):
+    if hasattr(func, '__qualname__') and hasattr(func, '__annotations__'): # pragma: no cover
         memof.__qualname__ = getattr(func, '__qualname__', '')
         memof.__annotations__ = getattr(func, '__annotations__', {})
 

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -3,8 +3,6 @@ import inspect
 import operator
 import sys
 
-from .compatibility import PY3
-
 __all__ = ('identity', 'thread_first', 'thread_last', 'memoize', 'compose',
            'pipe', 'complement', 'juxt', 'do', 'curry')
 
@@ -178,7 +176,8 @@ class curry(object):
         self.__name__ = getattr(func, '__name__', '<curried>')
         self.__doc__ = getattr(func, '__doc__', '<curry>')
         self.__module__ = getattr(func, '__module__', '')
-        if PY3:
+        # checking explicitly against PY3 fails for pypy3 and >3,3
+        if hasattr(func, '__qualname__') and hasattr(func, '__annotations__'):
             self.__qualname__ = getattr(func, '__qualname__', '')
             self.__annotations__ = getattr(func, '__annotations__', {})
 
@@ -359,7 +358,8 @@ def memoize(func, cache=None, key=None):
     memof.__doc__ = getattr(func, '__doc__', None)
     memof.__name__ = getattr(func, '__name__', '<memoized>')
     memof.__module__ = getattr(func, '__module__', '')
-    if PY3:
+    # checking explicitly against PY3 fails for pypy3 and >3.3
+    if hasattr(func, '__qualname__') and hasattr(func, '__annotations__'):
         memof.__qualname__ = getattr(func, '__qualname__', '')
         memof.__annotations__ = getattr(func, '__annotations__', {})
 

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -177,7 +177,7 @@ class curry(object):
         self.__doc__ = getattr(func, '__doc__', '<curry>')
         self.__module__ = getattr(func, '__module__', 'toolz.functoolz')
         # checking explicitly against PY3 fails for pypy3 and >3,3
-        if hasattr(func, '__qualname__') and hasattr(func, '__annotations__'): # pragma: no cover
+        if hasattr(func, '__qualname__'):  # pragma: no cover
             self.__qualname__ = getattr(func, '__qualname__', '')
             self.__annotations__ = getattr(func, '__annotations__', {})
 
@@ -359,7 +359,7 @@ def memoize(func, cache=None, key=None):
     memof.__name__ = getattr(func, '__name__', '<memoized>')
     memof.__module__ = getattr(func, '__module__', 'toolz.functoolz')
     # checking explicitly against PY3 fails for pypy3 and >3.3
-    if hasattr(func, '__qualname__') and hasattr(func, '__annotations__'): # pragma: no cover
+    if hasattr(func, '__qualname__'):  # pragma: no cover
         memof.__qualname__ = getattr(func, '__qualname__', '')
         memof.__annotations__ = getattr(func, '__annotations__', {})
 

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -125,14 +125,41 @@ def _num_required_args(func):
         return None
 
 
-# backport Python 3.4 update_wrapper
 def update_wrapper(wrapper,
                    wrapped,
                    assigned=WRAPPER_ASSIGNMENTS,
                    updated=WRAPPER_UPDATES):
 
     """Makes wrapper appear as the wrapped callable.
-    Backport of Python3.4's functools.update_wrapper
+
+    Backport of Python3.4's functools.update_wrapper. This version is
+    more intelligent than what's found in Python 2 as it uses a
+    try/except/else block when moving attributes rather than just
+    charitably assuming the attributes are present.
+
+    It also backports Python 3's `__wrapped__` attribute as well
+    to give access to the original callable.
+
+    WARNING: This function modifies the wrapper function.
+
+    More useful for class based decorator than closure based decorators.
+
+    >>> class Decorator(object):
+    ...     def __init__(self, f):
+    ...         update_wrapper(self, f)
+    ...         self._f = f
+    ...     def __call__(self, *a, **k):
+    ...         return self._f(*a, **k)
+
+    >>> @Decorator
+    ... def add(a, b):
+    ...     "a doc string"
+    ...     return a + b
+
+    >>> print(add.__name__)
+    add
+    >>> print(add.__doc__)
+    a doc string
     """
 
     for attr in assigned:
@@ -200,10 +227,9 @@ class curry(object):
             kwargs = _kwargs
             args = func.args + args
             func = func.func
-
-        # don't store any partial instances at all
-        # kludge for 2.6
-        self.__wrapped__ = func
+            # don't store any partial instances at all
+            # kludge for 2.6
+            self.__wrapped__ = func
 
         if kwargs:
             self._partial = partial(func, *args, **kwargs)
@@ -540,7 +566,32 @@ def do(func, x):
 
 
 def wraps(wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES):
-    """Decorator form of updated version of update_wrapper."""
+    """Decorator form of updated version of update_wrapper.
 
+    This is very useful for writing closure based decorators
+    rather than using update_wrapper manually on the closure.
+
+    WARNING: This function modifies what it's applied to.
+
+    >>> def decorator(f):
+    ...     @wraps(f)
+    ...     def wrapper(*a, **k):
+    ...         return f(*a, **k)
+    ...     return wrapper
+
+    >>> @decorator
+    ... def add(a, b):
+    ...     "a doc string"
+    ...     return a+b
+
+    >>> print(add.__name__)
+    add
+
+    >>> print(add.__doc__)
+    a doc string
+    """
+
+    # use functools.partial rather than curry to prevent
+    # recursion since curry *uses* update_wrapper to update itself
     return partial(update_wrapper, wrapped=wrapped,  # noqa
            assigned=assigned, updated=updated)  # noqa

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -201,6 +201,10 @@ class curry(object):
             args = func.args + args
             func = func.func
 
+        # don't store any partial instances at all
+        # kludge for 2.6
+        self.__wrapped__ = func
+
         if kwargs:
             self._partial = partial(func, *args, **kwargs)
         else:

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -3,6 +3,7 @@ import inspect
 import operator
 import sys
 
+from .compatibility import PY3
 
 __all__ = ('identity', 'thread_first', 'thread_last', 'memoize', 'compose',
            'pipe', 'complement', 'juxt', 'do', 'curry')
@@ -174,8 +175,12 @@ class curry(object):
         else:
             self._partial = partial(func, *args)
 
-        self.__doc__ = getattr(func, '__doc__', None)
-        self.__name__ = getattr(func, '__name__', '<curry>')
+        self.__name__ = getattr(func, '__name__', '<curried>')
+        self.__doc__ = getattr(func, '__doc__', '<curry>')
+        self.__module__ = getattr(func, '__module__', '')
+        if PY3:
+            self.__qualname__ = getattr(func, '__qualname__', '')
+            self.__annotations__ = getattr(func, '__annotations__', {})
 
     @property
     def func(self):
@@ -351,11 +356,14 @@ def memoize(func, cache=None, key=None):
             cache[k] = result
             return result
 
-    try:
-        memof.__name__ = func.__name__
-    except AttributeError:
-        pass
-    memof.__doc__ = func.__doc__
+    memof.__doc__ = getattr(func, '__doc__', None)
+    memof.__name__ = getattr(func, '__name__', '<memoized>')
+    memof.__module__ = getattr(func, '__module__', '')
+    if PY3:
+        memof.__qualname__ = getattr(func, '__qualname__', '')
+        memof.__annotations__ = getattr(func, '__annotations__', {})
+
+    memof.__dict__.update(getattr(func, '__dict__', {}))
     return memof
 
 

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -48,7 +48,12 @@ def test_memoize():
 
     assert mf(2, 3) == mf(2, 3)
     assert fn_calls == [1]  # function was only called once
-    assert mf.__doc__ == f.__doc__
+    assert mf.__doc__ == f.__doc__ and mf.__name__ == f.__name__
+
+    if PY3:
+        assert mf.__qualname__ == f.__qualname__
+        assert mf.__annotations__ == f.__annotations__
+
     assert raises(TypeError, lambda: mf(1, {}))
 
 
@@ -269,6 +274,19 @@ def test_curry_attributes_writable():
     if hasattr(f, 'func_name'):
         assert f.__name__ == f.func_name
 
+def test_curry_attributes_update_from_func():
+    def foo(a):
+        "a doc string"
+        return 4
+
+    f = curry(foo)
+    assert f.__name__ == 'foo'
+    assert f.__doc__ == 'a doc string'
+
+    if PY3:
+        # can't test actual annotations
+        # Python2 will refuse to compile code
+        assert f.__annotations__ == {}
 
 def test_curry_comparable():
     def foo(a, b, c=1):

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -50,7 +50,7 @@ def test_memoize():
     assert fn_calls == [1]  # function was only called once
     assert mf.__doc__ == f.__doc__ and mf.__name__ == f.__name__
 
-    if PY3:
+    if hasattr(mf, '__qualname__') and hasattr(mf, '__annotations__'):
         assert mf.__qualname__ == f.__qualname__
         assert mf.__annotations__ == f.__annotations__
 
@@ -283,7 +283,7 @@ def test_curry_attributes_update_from_func():
     assert f.__name__ == 'foo'
     assert f.__doc__ == 'a doc string'
 
-    if PY3:
+    if hasattr(f, '__annotations__'):
         # can't test actual annotations
         # Python2 will refuse to compile code
         assert f.__annotations__ == {}


### PR DESCRIPTION
Using update_wrapper and wraps would be preferable, however they both cause errors -- pickling issues in curry and attribute errors for memoizing a partial in Python 2. However, more than just `__name__` and `__doc__` should be transferred: `__module__`, if present and `__qualname__` and `__annotations__` in Python 3. Updating with `func.__dict__` isn't possible in curry (source of pickling problems), but should be done in memoize.
