### PR TITLE
Add support for OrderedDicts

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,3 +17,5 @@ Lars Buitinck                                   [@larsmans](http://github.com/la
 José Ricardo                                    [@josericardo](https://github.com/josericardo)
 
 Tom Prince                                      [@tomprince](https://github.com/tomprince)
+
+Bart van Merriënboer                            [@bartvm](https://github.com/bartvm)

--- a/toolz/curried_exceptions.py
+++ b/toolz/curried_exceptions.py
@@ -1,11 +1,18 @@
 import toolz
 
 
-def merge_with(fn, *dicts):
+def merge_with(fn, *dicts, **kwargs):
     if len(dicts) == 0:
         raise TypeError()
     else:
-        return toolz.merge_with(fn, *dicts)
+        return toolz.merge_with(fn, *dicts, **kwargs)
 
+
+def merge(*dicts, **kwargs):
+    if len(dicts) == 0:
+        raise TypeError()
+    else:
+        return toolz.merge(*dicts, **kwargs)
 
 merge_with.__doc__ = toolz.merge_with.__doc__
+merge.__doc__ = toolz.merge.__doc__

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -66,7 +66,7 @@ def merge_with(func, *dicts, **kwargs):
                 result[k] = [v]
             else:
                 result[k].append(v)
-    return factory((k, func(v)) for k, v in iteritems(result))
+    return valmap(func, result, factory=factory)
 
 
 def valmap(func, d, factory=dict):
@@ -80,7 +80,9 @@ def valmap(func, d, factory=dict):
         keymap
         itemmap
     """
-    return factory(zip(iterkeys(d), map(func, itervalues(d))))
+    rv = factory()
+    rv.update(zip(iterkeys(d), map(func, itervalues(d))))
+    return rv
 
 
 def keymap(func, d, factory=dict):
@@ -94,7 +96,9 @@ def keymap(func, d, factory=dict):
         valmap
         itemmap
     """
-    return factory(zip(map(func, iterkeys(d)), itervalues(d)))
+    rv = factory()
+    rv.update(zip(map(func, iterkeys(d)), itervalues(d)))
+    return rv
 
 
 def itemmap(func, d, factory=dict):
@@ -108,7 +112,9 @@ def itemmap(func, d, factory=dict):
         keymap
         valmap
     """
-    return factory(map(func, iteritems(d)))
+    rv = factory()
+    rv.update(map(func, iteritems(d)))
+    return rv
 
 
 def valfilter(predicate, d, factory=dict):
@@ -186,7 +192,9 @@ def assoc(d, key, value, factory=dict):
     >>> assoc({'x': 1}, 'y', 3)   # doctest: +SKIP
     {'x': 1, 'y': 3}
     """
-    return merge(d, factory([(key, value)]), factory=factory)
+    d2 = factory()
+    d2[key] = value
+    return merge(d, d2, factory=factory)
 
 
 def dissoc(d, key):

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -11,8 +11,8 @@ __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
 def _get_factory(f, kwargs):
     factory = kwargs.pop('factory', dict)
     if kwargs:
-        raise TypeError("{}() got an unexpected keyword argument "
-                        "'{}'".format(f.__name__, kwargs.popitem()[0]))
+        raise TypeError("{0}() got an unexpected keyword argument "
+                        "'{1}'".format(f.__name__, kwargs.popitem()[0]))
     return factory
 
 

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -57,9 +57,12 @@ def merge_with(func, *dicts):
 
     dict_ = OrderedDict
     result = OrderedDict()
+    return_ordered_dict = True
     for d in dicts:
-        if not isinstance(d, OrderedDict):
+        if return_ordered_dict and not isinstance(d, OrderedDict):
+            result = dict(result)
             dict_ = dict
+            return_ordered_dict = False
         for k, v in iteritems(d):
             if k not in result:
                 result[k] = [v]

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -56,15 +56,15 @@ def merge_with(func, *dicts):
     """
     if len(dicts) == 1 and not isinstance(dicts[0], dict):
         dicts = dicts[0]
+    dicts = list(dicts)
 
-    dict_ = OrderedDict
-    result = OrderedDict()
-    return_ordered_dict = True
+    if all(isinstance(d, OrderedDict) for d in dicts):
+        dict_ = OrderedDict
+    else:
+        dict_ = dict
+
+    result = dict_()
     for d in dicts:
-        if return_ordered_dict and not isinstance(d, OrderedDict):
-            result = dict(result)
-            dict_ = dict
-            return_ordered_dict = False
         for k, v in iteritems(d):
             if k not in result:
                 result[k] = [v]

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -1,11 +1,15 @@
 import operator
-from collections import OrderedDict
+import collections
 from toolz.compatibility import (map, zip, iteritems, iterkeys, itervalues,
                                  reduce)
 
 __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
            'valfilter', 'keyfilter', 'itemfilter',
            'assoc', 'dissoc', 'update_in', 'get_in')
+
+# Python 2.6 compatibility
+OrderedDict = getattr(collections, 'OrderedDict',
+                      type('OrderedDict', (dict,), {}))
 
 
 def merge(*dicts):

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -30,9 +30,11 @@ def merge(*dicts):
         dicts = dicts[0]
 
     rv = OrderedDict()
+    return_ordered_dict = True
     for d in dicts:
-        if not isinstance(d, OrderedDict):
+        if return_ordered_dict and not isinstance(d, OrderedDict):
             rv = dict(rv)
+            return_ordered_dict = False
         rv.update(d)
     return rv
 

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -7,7 +7,15 @@ __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
            'assoc', 'dissoc', 'update_in', 'get_in')
 
 
-def merge(*dicts):
+def _get_factory(f, kwargs):
+    factory = kwargs.pop('factory', dict)
+    if kwargs:
+        raise TypeError("{}() got an unexpected keyword argument "
+                        "'{}'".format(f.__name__, kwargs.popitem()[0]))
+    return factory
+
+
+def merge(*dicts, **kwargs):
     """ Merge a collection of dictionaries
 
     >>> merge({1: 'one'}, {2: 'two'})
@@ -23,14 +31,15 @@ def merge(*dicts):
     """
     if len(dicts) == 1 and not isinstance(dicts[0], dict):
         dicts = dicts[0]
+    factory = _get_factory(merge, kwargs)
 
-    rv = {}
+    rv = factory()
     for d in dicts:
         rv.update(d)
     return rv
 
 
-def merge_with(func, *dicts):
+def merge_with(func, *dicts, **kwargs):
     """ Merge dictionaries and apply function to combined values
 
     A key may occur in more than one dict, and all values mapped from the key
@@ -47,18 +56,19 @@ def merge_with(func, *dicts):
     """
     if len(dicts) == 1 and not isinstance(dicts[0], dict):
         dicts = dicts[0]
+    factory = _get_factory(merge_with, kwargs)
 
-    result = {}
+    result = factory()
     for d in dicts:
         for k, v in iteritems(d):
             if k not in result:
                 result[k] = [v]
             else:
                 result[k].append(v)
-    return dict((k, func(v)) for k, v in iteritems(result))
+    return factory((k, func(v)) for k, v in iteritems(result))
 
 
-def valmap(func, d):
+def valmap(func, d, factory=dict):
     """ Apply function to values of dictionary
 
     >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
@@ -69,10 +79,10 @@ def valmap(func, d):
         keymap
         itemmap
     """
-    return dict(zip(iterkeys(d), map(func, itervalues(d))))
+    return factory(zip(iterkeys(d), map(func, itervalues(d))))
 
 
-def keymap(func, d):
+def keymap(func, d, factory=dict):
     """ Apply function to keys of dictionary
 
     >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
@@ -83,10 +93,10 @@ def keymap(func, d):
         valmap
         itemmap
     """
-    return dict(zip(map(func, iterkeys(d)), itervalues(d)))
+    return factory(zip(map(func, iterkeys(d)), itervalues(d)))
 
 
-def itemmap(func, d):
+def itemmap(func, d, factory=dict):
     """ Apply function to items of dictionary
 
     >>> accountids = {"Alice": 10, "Bob": 20}
@@ -97,10 +107,10 @@ def itemmap(func, d):
         keymap
         valmap
     """
-    return dict(map(func, iteritems(d)))
+    return factory(map(func, iteritems(d)))
 
 
-def valfilter(predicate, d):
+def valfilter(predicate, d, factory=dict):
     """ Filter items in dictionary by value
 
     >>> iseven = lambda x: x % 2 == 0
@@ -113,14 +123,14 @@ def valfilter(predicate, d):
         itemfilter
         valmap
     """
-    rv = {}
+    rv = factory()
     for k, v in iteritems(d):
         if predicate(v):
             rv[k] = v
     return rv
 
 
-def keyfilter(predicate, d):
+def keyfilter(predicate, d, factory=dict):
     """ Filter items in dictionary by key
 
     >>> iseven = lambda x: x % 2 == 0
@@ -133,14 +143,14 @@ def keyfilter(predicate, d):
         itemfilter
         keymap
     """
-    rv = {}
+    rv = factory()
     for k, v in iteritems(d):
         if predicate(k):
             rv[k] = v
     return rv
 
 
-def itemfilter(predicate, d):
+def itemfilter(predicate, d, factory=dict):
     """ Filter items in dictionary by item
 
     >>> def isvalid(item):
@@ -156,7 +166,7 @@ def itemfilter(predicate, d):
         valfilter
         itemmap
     """
-    rv = {}
+    rv = factory()
     for item in iteritems(d):
         if predicate(item):
             k, v = item
@@ -164,7 +174,7 @@ def itemfilter(predicate, d):
     return rv
 
 
-def assoc(d, key, value):
+def assoc(d, key, value, factory=dict):
     """
     Return a new dict with new key value pair
 
@@ -175,7 +185,7 @@ def assoc(d, key, value):
     >>> assoc({'x': 1}, 'y', 3)   # doctest: +SKIP
     {'x': 1, 'y': 3}
     """
-    return merge(d, {key: value})
+    return merge(d, factory([(key, value)]), factory=factory)
 
 
 def dissoc(d, key):
@@ -193,7 +203,7 @@ def dissoc(d, key):
     return d2
 
 
-def update_in(d, keys, func, default=None):
+def update_in(d, keys, func, default=None, factory=dict):
     """ Update value in a (potentially) nested dictionary
 
     inputs:
@@ -230,10 +240,11 @@ def update_in(d, keys, func, default=None):
     assert len(keys) > 0
     k, ks = keys[0], keys[1:]
     if ks:
-        return assoc(d, k, update_in(d.get(k, {}), ks, func, default))
+        return assoc(d, k, update_in(d.get(k, factory()), ks, func, default),
+                     factory=factory)
     else:
         innermost = func(d.get(k)) if (k in d) else func(default)
-        return assoc(d, k, innermost)
+        return assoc(d, k, innermost, factory=factory)
 
 
 def get_in(keys, coll, default=None, no_default=False):

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -16,15 +16,6 @@ def _get_factory(f, kwargs):
     return factory
 
 
-def _update(self, other):
-    if callable(getattr(self, 'update', None)):
-        self.update(other)
-    else:
-        for k, v in other.iteritems():
-            self[k] = v
-    return self
-
-
 def merge(*dicts, **kwargs):
     """ Merge a collection of dictionaries
 
@@ -45,7 +36,7 @@ def merge(*dicts, **kwargs):
 
     rv = factory()
     for d in dicts:
-        _update(rv, d)
+        rv.update(d)
     return rv
 
 

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -15,6 +15,15 @@ def _get_factory(f, kwargs):
     return factory
 
 
+def _update(self, other):
+    if callable(getattr(self, 'update', None)):
+        self.update(other)
+    else:
+        for k, v in other.iteritems():
+            self[k] = v
+    return self
+
+
 def merge(*dicts, **kwargs):
     """ Merge a collection of dictionaries
 
@@ -35,7 +44,7 @@ def merge(*dicts, **kwargs):
 
     rv = factory()
     for d in dicts:
-        rv.update(d)
+        _update(rv, d)
     return rv
 
 

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -1,3 +1,4 @@
+import copy
 import operator
 from toolz.compatibility import (map, zip, iteritems, iterkeys, itervalues,
                                  reduce)
@@ -207,7 +208,7 @@ def dissoc(d, key):
     >>> dissoc({'x': 1, 'y': 2}, 'y')
     {'x': 1}
     """
-    d2 = d.copy()
+    d2 = copy.copy(d)
     del d2[key]
     return d2
 

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -1,15 +1,10 @@
 import operator
-import collections
 from toolz.compatibility import (map, zip, iteritems, iterkeys, itervalues,
                                  reduce)
 
 __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
            'valfilter', 'keyfilter', 'itemfilter',
            'assoc', 'dissoc', 'update_in', 'get_in')
-
-# Python 2.6 compatibility
-OrderedDict = getattr(collections, 'OrderedDict',
-                      type('OrderedDict', (dict,), {}))
 
 
 def merge(*dicts):
@@ -29,12 +24,8 @@ def merge(*dicts):
     if len(dicts) == 1 and not isinstance(dicts[0], dict):
         dicts = dicts[0]
 
-    rv = OrderedDict()
-    return_ordered_dict = True
+    rv = {}
     for d in dicts:
-        if return_ordered_dict and not isinstance(d, OrderedDict):
-            rv = dict(rv)
-            return_ordered_dict = False
         rv.update(d)
     return rv
 
@@ -56,21 +47,15 @@ def merge_with(func, *dicts):
     """
     if len(dicts) == 1 and not isinstance(dicts[0], dict):
         dicts = dicts[0]
-    dicts = list(dicts)
 
-    if all(isinstance(d, OrderedDict) for d in dicts):
-        dict_ = OrderedDict
-    else:
-        dict_ = dict
-
-    result = dict_()
+    result = {}
     for d in dicts:
         for k, v in iteritems(d):
             if k not in result:
                 result[k] = [v]
             else:
                 result[k].append(v)
-    return dict_((k, func(v)) for k, v in iteritems(result))
+    return dict((k, func(v)) for k, v in iteritems(result))
 
 
 def valmap(func, d):
@@ -98,7 +83,7 @@ def keymap(func, d):
         valmap
         itemmap
     """
-    return type(d)(zip(map(func, iterkeys(d)), itervalues(d)))
+    return dict(zip(map(func, iterkeys(d)), itervalues(d)))
 
 
 def itemmap(func, d):
@@ -112,7 +97,7 @@ def itemmap(func, d):
         keymap
         valmap
     """
-    return type(d)(map(func, iteritems(d)))
+    return dict(map(func, iteritems(d)))
 
 
 def valfilter(predicate, d):
@@ -128,7 +113,7 @@ def valfilter(predicate, d):
         itemfilter
         valmap
     """
-    rv = type(d)()
+    rv = {}
     for k, v in iteritems(d):
         if predicate(v):
             rv[k] = v
@@ -148,7 +133,7 @@ def keyfilter(predicate, d):
         itemfilter
         keymap
     """
-    rv = type(d)()
+    rv = {}
     for k, v in iteritems(d):
         if predicate(k):
             rv[k] = v
@@ -171,7 +156,7 @@ def itemfilter(predicate, d):
         valfilter
         itemmap
     """
-    rv = type(d)()
+    rv = {}
     for item in iteritems(d):
         if predicate(item):
             k, v = item
@@ -190,7 +175,7 @@ def assoc(d, key, value):
     >>> assoc({'x': 1}, 'y', 3)   # doctest: +SKIP
     {'x': 1, 'y': 3}
     """
-    return merge(d, type(d)([(key, value)]))
+    return merge(d, {key: value})
 
 
 def dissoc(d, key):
@@ -245,7 +230,7 @@ def update_in(d, keys, func, default=None):
     assert len(keys) > 0
     k, ks = keys[0], keys[1:]
     if ks:
-        return assoc(d, k, update_in(d.get(k, type(d)()), ks, func, default))
+        return assoc(d, k, update_in(d.get(k, {}), ks, func, default))
     else:
         innermost = func(d.get(k)) if (k in d) else func(default)
         return assoc(d, k, innermost)

--- a/toolz/tests/test_curried.py
+++ b/toolz/tests/test_curried.py
@@ -1,6 +1,8 @@
 import toolz
 import toolz.curried
-from toolz.curried import take, first, second, sorted, merge_with, reduce
+from toolz.curried import (take, first, second, sorted, merge_with, reduce,
+                           merge)
+from collections import defaultdict
 from operator import add
 
 
@@ -10,6 +12,12 @@ def test_take():
 
 def test_first():
     assert first is toolz.itertoolz.first
+
+
+def test_merge():
+    assert merge(factory=lambda: defaultdict(int))({1: 1}) == {1: 1}
+    assert merge({1: 1}) == {1: 1}
+    assert merge({1: 1}, factory=lambda: defaultdict(int)) == {1: 1}
 
 
 def test_merge_with():

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -1,3 +1,4 @@
+import sys
 import collections
 
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
@@ -7,12 +8,13 @@ from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
 # Python 2.6 compatibility
 _OrderedDict = getattr(collections, 'OrderedDict',
                        type('OrderedDict', (dict,), {}))
+PY26 = not all(i <= j for i, j in zip((2, 7), sys.version_info[:2]))
 
 
 class OrderedDict(_OrderedDict):
     def __eq__(self, other):
-        # Ensure that comparisons against dict return False
-        if not isinstance(other, _OrderedDict):
+        # Ensure that comparisons against dict return False on Python 2.7+
+        if not PY26 and not isinstance(other, _OrderedDict):
             return False
         return super(OrderedDict, self).__eq__(other)
 

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -2,6 +2,7 @@ from collections import defaultdict as _defaultdict
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
                              assoc, dissoc, keyfilter, valfilter, itemmap,
                              itemfilter)
+from toolz.utils import raises
 
 
 class defaultdict(_defaultdict):
@@ -126,3 +127,4 @@ def test_factory():
             defaultdict(int, {1: 2, 2: 3}))
     assert not (merge(defaultdict(int, {1: 2}), {2: 3},
                       factory=lambda: defaultdict(int)) == {1: 2, 2: 3})
+    assert raises(TypeError, lambda: merge({1: 2}, {2: 3}, factoryy=dict))

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -1,6 +1,14 @@
+from collections import defaultdict as _defaultdict
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
                              assoc, dissoc, keyfilter, valfilter, itemmap,
                              itemfilter)
+
+
+class defaultdict(_defaultdict):
+    def __eq__(self, other):
+        return (super(defaultdict, self).__eq__(other) and
+                isinstance(other, _defaultdict) and
+                self.default_factory == other.default_factory)
 
 
 def inc(x):
@@ -109,3 +117,12 @@ def test_update_in():
     oldd = d
     update_in(d, ['x'], inc)
     assert d is oldd
+
+
+def test_factory():
+    assert merge(defaultdict(int, {1: 2}), {2: 3}) == {1: 2, 2: 3}
+    assert (merge(defaultdict(int, {1: 2}), {2: 3},
+                  factory=lambda: defaultdict(int)) ==
+            defaultdict(int, {1: 2, 2: 3}))
+    assert not (merge(defaultdict(int, {1: 2}), {2: 3},
+                      factory=lambda: defaultdict(int)) == {1: 2, 2: 3})

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -1,13 +1,14 @@
-from toolz.utils import raises
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
                              assoc, dissoc, keyfilter, valfilter, itemmap,
                              itemfilter)
 
 
-inc = lambda x: x + 1
+def inc(x):
+    return x + 1
 
 
-iseven = lambda i: i % 2 == 0
+def iseven(i):
+    return i % 2 == 0
 
 
 def test_merge():

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -1,41 +1,17 @@
-import sys
-import collections
-
+from toolz.utils import raises
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
                              assoc, dissoc, keyfilter, valfilter, itemmap,
                              itemfilter)
 
-# Python 2.6 compatibility
-_OrderedDict = getattr(collections, 'OrderedDict',
-                       type('OrderedDict', (dict,), {}))
-PY26 = not all(i <= j for i, j in zip((2, 7), sys.version_info[:2]))
+
+inc = lambda x: x + 1
 
 
-class OrderedDict(_OrderedDict):
-    def __eq__(self, other):
-        # Ensure that comparisons against dict return False on Python 2.7+
-        if not PY26 and not isinstance(other, _OrderedDict):
-            return False
-        return super(OrderedDict, self).__eq__(other)
-
-
-def inc(x):
-    return x + 1
-
-
-def iseven(i):
-    return i % 2 == 0
+iseven = lambda i: i % 2 == 0
 
 
 def test_merge():
     assert merge({1: 1, 2: 2}, {3: 4}) == {1: 1, 2: 2, 3: 4}
-    assert merge({1: 1}, OrderedDict([(3, 4)])) == {1: 1, 3: 4}
-    assert merge(OrderedDict([(3, 4)]), {1: 1}) == {1: 1, 3: 4}
-    assert (merge(OrderedDict([(1, 1)]), OrderedDict([(2, 2), (1, 3)])) ==
-            OrderedDict([(1, 3), (2, 2)]))
-    dicts = (OrderedDict([(1, 1)]), OrderedDict([(1, 2)]),
-             OrderedDict([(2, 3)]))
-    assert merge(dicts) == OrderedDict([(1, 2), (2, 3)])
 
 
 def test_merge_iterable_arg():
@@ -50,14 +26,6 @@ def test_merge_with():
     dicts = {1: 1, 2: 2, 3: 3}, {1: 10, 2: 20}
     assert merge_with(sum, *dicts) == {1: 11, 2: 22, 3: 3}
     assert merge_with(tuple, *dicts) == {1: (1, 10), 2: (2, 20), 3: (3,)}
-
-    ordered_dicts = (OrderedDict([(1, 1), (2, 2)]),
-                     OrderedDict([(1, 10), (2, 20)]))
-    assert merge_with(sum, ordered_dicts) == OrderedDict([(1, 11), (2, 22)])
-    assert merge_with(sum, *ordered_dicts) == OrderedDict([(1, 11), (2, 22)])
-
-    mixed_dicts = OrderedDict([(1, 10)]), {1: 1}, OrderedDict([(2, 3)])
-    assert merge_with(sum, mixed_dicts) == {1: 11, 2: 3}
 
     assert not merge_with(sum)
 


### PR DESCRIPTION
I like the Dicttoolz package, but for many of my use cases I need the deterministic behaviour of `OrderedDict`. Adapting Dicttoolz to return `OrderedDict` if all of its inputs are one is relatively straightforward. Is this something you would consider merging?