### PR TITLE
compose tweaks

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,3 +23,5 @@ Bart van Merriënboer                            [@bartvm](https://github.com/ba
 Nikolaos-Digenis Karagiannis                    [@digenis](https://github.com/digenis/)
 
 [Antonio Lima](https://twitter.com/themiurgo)   [@themiurgo](https://github.com/themiurgo/)
+
+Joe Jevnik                                      [@llllllllll](https://github.com/llllllllll)

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -401,7 +401,7 @@ class Compose(object):
         try:
             return (
                 'lambda *args, **kwargs: ' +
-                composed_doc(self.first, *self.funcs)
+                composed_doc(*reversed((self.first,) + self.funcs))
             )
         except AttributeError:
             # One of our callables does not have a `__name__`, whatever.

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -387,6 +387,35 @@ class Compose(object):
     def __setstate__(self, state):
         self.first, self.funcs = state
 
+    @property
+    def __doc__(self):
+        def composed_doc(*fs):
+            """Generate a docstring for the composition of fs.
+            """
+            if not fs:
+                # Argument name for the docstring.
+                return '*args, **kwargs'
+
+            return '{f}({g})'.format(f=fs[0].__name__, g=composed_doc(*fs[1:]))
+
+        try:
+            return (
+                'lambda *args, **kwargs: ' +
+                composed_doc(self.first, *self.funcs)
+            )
+        except AttributeError:
+            # One of our callables does not have a `__name__`, whatever.
+            return 'A composition of functions'
+
+    @property
+    def __name__(self):
+        try:
+            return '_of_'.join(
+                f.__name__ for f in reversed((self.first,) + self.funcs),
+            )
+        except AttributeError:
+            return type(self).__name__
+
 
 def compose(*funcs):
     """ Compose functions to operate in series.

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -368,23 +368,24 @@ class Compose(object):
     See Also:
         compose
     """
-    __slots__ = ['funcs']
+    __slots__ = 'first', 'funcs'
 
-    def __init__(self, *funcs):
-        self.funcs = funcs
+    def __init__(self, funcs):
+        funcs = tuple(reversed(funcs))
+        self.first = funcs[0]
+        self.funcs = funcs[1:]
 
     def __call__(self, *args, **kwargs):
-        fns = list(reversed(self.funcs))
-        ret = fns[0](*args, **kwargs)
-        for f in fns[1:]:
+        ret = self.first(*args, **kwargs)
+        for f in self.funcs:
             ret = f(ret)
         return ret
 
     def __getstate__(self):
-        return self.funcs
+        return self.first, self.funcs
 
     def __setstate__(self, state):
-        self.funcs = tuple(state)
+        self.first, self.funcs = state
 
 
 def compose(*funcs):
@@ -409,7 +410,7 @@ def compose(*funcs):
     if len(funcs) == 1:
         return funcs[0]
     else:
-        return Compose(*funcs)
+        return Compose(funcs)
 
 
 def pipe(data, *funcs):

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -436,6 +436,24 @@ def test_compose():
 
     assert compose(str, inc, f)(1, 2, c=3) == '10'
 
+    # Define two functions with different names
+    def f(a):
+        return a
+
+    def g(a):
+        return a
+
+    composed = compose(f, g)
+    assert composed.__name__ == 'f_of_g'
+    assert composed.__doc__ == 'lambda *args, **kwargs: f(g(*args, **kwargs)'
+
+    # Create an object with no __name__.
+    h = object()
+
+    composed = compose(f, h)
+    assert composed.__name__ == 'composed'
+    assert composed.__doc__ == 'A composition of functions'
+
 
 def test_pipe():
     assert pipe(1, inc) == 2

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -445,13 +445,13 @@ def test_compose():
 
     composed = compose(f, g)
     assert composed.__name__ == 'f_of_g'
-    assert composed.__doc__ == 'lambda *args, **kwargs: f(g(*args, **kwargs)'
+    assert composed.__doc__ == 'lambda *args, **kwargs: f(g(*args, **kwargs))'
 
     # Create an object with no __name__.
     h = object()
 
     composed = compose(f, h)
-    assert composed.__name__ == 'composed'
+    assert composed.__name__ == 'Compose'
     assert composed.__doc__ == 'A composition of functions'
 
 


### PR DESCRIPTION
By caching the slice, we can save some time:

#### master
```python
In [1]: from toolz import compose, identity

In [2]: f = compose(*([identity] * 255))

In [3]: %timeit f(None)
100000 loops, best of 3: 19.7 µs per loop
```

#### patch
```python
In [1]: from toolz import compose, identity

In [2]: f = compose(*([identity] * 255))

In [3]: %timeit f(None)
10000 loops, best of 3: 16.1 µs per loop
```

Also, this creates a docstring that shows the lambda equivalent, for example:

```python
>>> compose(f, g, h).__doc__
'lambda *args, **kwargs: h(g(f(*args, **kwargs)))'
```

This also creates a really nice name for the composed function:

```python
>>> compose(f, g, h).__name__
'f_of_g_of_h'
```