### PR TITLE
ENH: Adds PeekableIterator

### DIFF
--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -3,7 +3,8 @@ import sys
 PY3 = sys.version_info[0] > 2
 
 __all__ = ('PY3', 'map', 'filter', 'range', 'zip', 'reduce', 'zip_longest',
-           'iteritems', 'iterkeys', 'itervalues', 'filterfalse')
+           'iteritems', 'iterkeys', 'itervalues', 'filterfalse',
+           'Queue', 'Empty')
 
 if PY3:
     map = map
@@ -13,6 +14,7 @@ if PY3:
     from functools import reduce
     from itertools import zip_longest
     from itertools import filterfalse
+    from queue import Queue, Empty
     iteritems = operator.methodcaller('items')
     iterkeys = operator.methodcaller('keys')
     itervalues = operator.methodcaller('values')
@@ -24,6 +26,7 @@ else:
     from itertools import ifilterfalse as filterfalse
     from itertools import izip as zip
     from itertools import izip_longest as zip_longest
+    from Queue import Queue, Empty
     iteritems = operator.methodcaller('iteritems')
     iterkeys = operator.methodcaller('iterkeys')
     itervalues = operator.methodcaller('itervalues')

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -11,7 +11,7 @@ from toolz.itertoolz import (remove, groupby, merge_sorted,
                              reduceby, iterate, accumulate,
                              sliding_window, count, partition,
                              partition_all, take_nth, pluck, join,
-                             diff, topk, peek)
+                             diff, topk, peek, PeekableIterator)
 from toolz.compatibility import range, filter
 from operator import add, mul
 
@@ -467,3 +467,26 @@ def test_peek():
     assert list(blist) == alist
 
     assert raises(StopIteration, lambda: peek([]))
+
+
+def test_peekable_iterator_iter():
+    peekable = PeekableIterator(iter([1, 2, 3]))
+    assert iter(peekable) is peekable
+    assert next(peekable) == 1
+    assert list(peekable) == [2, 3]
+
+
+def test_peekable_iterator_peek():
+    peekable = PeekableIterator(iter([1, 2, 3]))
+    assert peekable.peek(2) == (1, 2)
+    assert list(peekable) == [1, 2, 3]
+
+
+def test_peekable_iterator_lookahead_iter():
+    peekable = PeekableIterator(iter([1, 2, 3]))
+    for n in peekable.lookahead_iter():
+        if n == 2:
+            break
+        assert n == 1
+
+    assert list(peekable) == [2, 3]


### PR DESCRIPTION
Here is one that I was using in (quasiquotes)[https://github.com/llllllllll/quasiquotes/blob/master/quasiquotes/codec/tokenizer.py#L290] when working on a custom tokenize to look ahead at the next tokens to detirmine which branch to execute without pulling all the tokens out of the stream. I am also using it in some data loading code to check on data types before writing stuff.

I realize there is already a `peek` and that this sort of does a lot of the same things. I am not sure how you feel about having both but I am offering it if you are iterested.