### PR TITLE
Add multiple key arguments to dissoc.

### DIFF
--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -197,18 +197,19 @@ def assoc(d, key, value, factory=dict):
     return merge(d, d2, factory=factory)
 
 
-def dissoc(d, key):
+def dissoc(d, *keys):
     """
-    Return a new dict with the given key removed.
+    Return a new dict with the given key(s) removed.
 
-    New dict has d[key] deleted.
+    New dict has d[key] deleted for each supplied key.
     Does not modify the initial dictionary.
 
     >>> dissoc({'x': 1, 'y': 2}, 'y')
     {'x': 1}
     """
     d2 = copy.copy(d)
-    del d2[key]
+    for key in keys:
+        del d2[key]
     return d2
 
 

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -206,6 +206,8 @@ def dissoc(d, *keys):
 
     >>> dissoc({'x': 1, 'y': 2}, 'y')
     {'x': 1}
+    >>> dissoc({'x': 1, 'y': 2}, 'y', 'x')
+    {}
     """
     d2 = copy.copy(d)
     for key in keys:

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -93,6 +93,7 @@ class TestDict(object):
         assert dissoc(D({"a": 1}), "a") == D({})
         assert dissoc(D({"a": 1, "b": 2}), "a") == D({"b": 2})
         assert dissoc(D({"a": 1, "b": 2}), "b") == D({"a": 1})
+        assert dissoc(D({"a": 1, "b": 2}), "a", "b") == D({})
 
         # Verify immutability:
         d = D({'x': 1})


### PR DESCRIPTION
Fixes #256 .  @mrocklin @eriknw do you want the docstring extended to include e.g. a 3-ary example?