### PR TITLE
ENH: Adds excepts

### DIFF
--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -583,14 +583,14 @@ class excepts(object):
 
     Examples
     --------
-    >>> excepting = excepts(lambda a: [1, 2].index(a), ValueError, lambda: -1)
+    >>> excepting = excepts(ValueError, lambda a: [1, 2].index(a), lambda: -1)
     >>> excepting(1)
     0
     >>> excepting(3)
     -1
 
     Multiple exceptions and default except clause.
-    >>> excepting = excepts(lambda a: a[0], (IndexError, KeyError))
+    >>> excepting = excepts((IndexError, KeyError), lambda a: a[0])
     >>> excepting([])
     >>> excepting([1])
     1
@@ -598,9 +598,9 @@ class excepts(object):
     >>> excepting({0: 1})
     1
     """
-    def __init__(self, f, exc, default=return_none):
-        self.f = f
+    def __init__(self, exc, f, default=return_none):
         self.exc = exc
+        self.f = f
         self.default = default
 
     def __call__(self, *args, **kwargs):

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -544,6 +544,7 @@ def do(func, x):
     func(x)
     return x
 
+
 @curry
 def flip(func, a, b):
     """Call the function call with the arguments flipped.

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -609,21 +609,17 @@ class excepts(object):
         except self.exc:
             return self.default()
 
-    @object.__new__
-    class __name__(object):
-        def __get__(self, instance, owner):
-            if instance is None:
-                return 'excepts'
-
-            exc = instance.exc
-            try:
-                if isinstance(exc, tuple):
-                    exc_name = '_or_'.join(map(attrgetter('__name__'), exc))
-                else:
-                    exc_name = exc.__name__
-                return '%s_excepting_%s' % (instance.f.__name__, exc_name)
-            except AttributeError:
-                return 'excepting'
+    @property
+    def __name__(self):
+        exc = self.exc
+        try:
+            if isinstance(exc, tuple):
+                exc_name = '_or_'.join(map(attrgetter('__name__'), exc))
+            else:
+                exc_name = exc.__name__
+            return '%s_excepting_%s' % (self.f.__name__, exc_name)
+        except AttributeError:
+            return 'excepting'
 
     @partial(lambda a, b=__doc__: a(b))  # close over the class __doc__
     class __doc__(object):

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -555,6 +555,17 @@ def test_excepts():
     assert 'return_none' in excepting.__doc__
     assert 'Returns None' in excepting.__doc__
 
+    def raise_(a):
+        """A function that raises an instance of the exception type given.
+        """
+        raise a()
+
+    excepting = excepts((ValueError, KeyError), raise_)
+    assert excepting(ValueError) is None
+    assert excepting(KeyError) is None
+    assert raises(TypeError, lambda: excepting(TypeError))
+    assert raises(NotImplementedError, lambda: excepting(NotImplementedError))
+
     excepting = excepts(object(), object(), object())
     assert excepting.__name__ == 'excepting'
     assert excepting.__doc__ == excepts.__doc__

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -514,8 +514,8 @@ def test_excepts():
     # These are descriptors, make sure this works correctly.
     assert excepts.__name__ == 'excepts'
     assert excepts.__doc__.startswith(
-        'A wrapper around a function to catch exceptions and'
-        ' return some default.\n'
+        'A wrapper around a function to catch exceptions and\n'
+        '    dispatch to a handler.\n'
     )
 
     def idx(a):
@@ -523,12 +523,13 @@ def test_excepts():
         """
         return [1, 2].index(a)
 
-    def default_func():
-        """default_func docstring
+    def handler(e):
+        """handler docstring
         """
+        assert isinstance(e, ValueError)
         return -1
 
-    excepting = excepts(ValueError, idx, default_func)
+    excepting = excepts(ValueError, idx, handler)
     assert excepting(1) == 0
     assert excepting(2) == 1
     assert excepting(3) == -1
@@ -536,7 +537,7 @@ def test_excepts():
     assert excepting.__name__ == 'idx_excepting_ValueError'
     assert 'idx docstring' in excepting.__doc__
     assert 'ValueError' in excepting.__doc__
-    assert 'default_func docstring' in excepting.__doc__
+    assert 'handler docstring' in excepting.__doc__
 
     def getzero(a):
         """getzero docstring

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -528,7 +528,7 @@ def test_excepts():
         """
         return -1
 
-    excepting = excepts(idx, ValueError, default_func)
+    excepting = excepts(ValueError, idx, default_func)
     assert excepting(1) == 0
     assert excepting(2) == 1
     assert excepting(3) == -1
@@ -543,7 +543,7 @@ def test_excepts():
         """
         return a[0]
 
-    excepting = excepts(getzero, (IndexError, KeyError))
+    excepting = excepts((IndexError, KeyError), getzero)
     assert excepting([]) is None
     assert excepting([1]) == 1
     assert excepting({}) is None


### PR DESCRIPTION
The idea of this is to use exception based api functions alongside your normal functional code.

for example:
```python
map(itemgetter('key'), seq) -> map(excepts(itemgetter('key'), KeyError), seq)
```

This helps us get around the fact that I cannot put an `except` clause in a lambda. I have found this to be very useful in my own code.

Most of this code is for fresh `__name__` and `__doc__` attributes.