### PR TITLE
Memoize perf

### DIFF
--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -48,7 +48,7 @@ def test_memoize():
         return x + y
     mf = memoize(f)
 
-    assert mf(2, 3) == mf(2, 3)
+    assert mf(2, 3) is mf(2, 3)
     assert fn_calls == [1]  # function was only called once
     assert mf.__doc__ == f.__doc__
     assert raises(TypeError, lambda: mf(1, {}))


### PR DESCRIPTION
This patch pre-computes the key function. The underlying function cannot stop being unary or stop accepting kwargs in between calls so we can pull this check out of the wrapper.

#### branch:
```
In [4]: %timeit f(1, 2)
The slowest run took 10.37 times longer than the fastest. This could mean that an intermediate result is being cached
1000000 loops, best of 3: 465 ns per loop
```

#### master:
```
In [4]: %timeit f(1, 2)
The slowest run took 8.79 times longer than the fastest. This could mean that an intermediate result is being cached
1000000 loops, best of 3: 570 ns per loop
```