### PR TITLE
ENH: Set __wrapped__ attribute on curry and memoize.

### DIFF
--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -183,6 +183,7 @@ class curry(object):
     @property
     def func(self):
         return self._partial.func
+    __wrapped__ = func
 
     @property
     def args(self):
@@ -359,6 +360,7 @@ def memoize(func, cache=None, key=None):
     except AttributeError:
         pass
     memof.__doc__ = func.__doc__
+    memof.__wrapped__ = func
     return memof
 
 

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -1,6 +1,5 @@
 import platform
 
-
 from toolz.functoolz import (thread_first, thread_last, memoize, curry,
                              compose, pipe, complement, do, juxt, flip)
 from toolz.functoolz import _num_required_args
@@ -151,6 +150,17 @@ def test_memoize_key():
 
     assert f(1, 2) == 3
     assert f(1, 3) == 3
+
+
+def test_memoize_wrapped():
+
+    def foo():
+        """
+        Docstring
+        """
+        pass
+    memoized_foo = memoize(foo)
+    assert memoized_foo.__wrapped__ is foo
 
 
 def test_curry_simple():
@@ -411,6 +421,17 @@ def test_memoize_on_classmethods():
 
     assert a.addstatic(3, 4) == 7
     assert A.addstatic(3, 4) == 7
+
+
+def test_curry_wrapped():
+
+    def foo(a):
+        """
+        Docstring
+        """
+        pass
+    curried_foo = curry(foo)
+    assert curried_foo.__wrapped__ is foo
 
 
 def test__num_required_args():


### PR DESCRIPTION
Several functions in the stdlib ``functools`` module set this attribute
on decorated functions (most notably, functools.wraps).  Consequently,
many introspection tools (e.g. IPython's ? and ?? operators) use
``__wrapped__`` to find the source for functions.

This change makes ``curry`` and ``memoize`` provide a ``__wrapped__``
attribute so that users searching for the source of a curried function
find the actual function source rather than the source for ``curry``.