### PR TITLE
Add assoc_in function.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,3 +25,5 @@ Nikolaos-Digenis Karagiannis                    [@digenis](https://github.com/di
 [Antonio Lima](https://twitter.com/themiurgo)   [@themiurgo](https://github.com/themiurgo/)
 
 Joe Jevnik                                      [@llllllllll](https://github.com/llllllllll)
+
+Rory Kirchner                                      [@roryk](https://github.com/roryk)

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -76,6 +76,7 @@ Dicttoolz
 .. autosummary::
    assoc
    dissoc
+   assoc_in
    get_in
    keyfilter
    keymap

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -5,7 +5,7 @@ from toolz.compatibility import (map, zip, iteritems, iterkeys, itervalues,
 
 __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
            'valfilter', 'keyfilter', 'itemfilter',
-           'assoc', 'dissoc', 'update_in', 'get_in')
+           'assoc', 'dissoc', 'assoc_in', 'update_in', 'get_in')
 
 
 def _get_factory(f, kwargs):
@@ -216,6 +216,22 @@ def dissoc(d, *keys):
         if key in d2:
             del d2[key]
     return d2
+
+
+def assoc_in(d, keys, value, factory=dict):
+    """
+    Return a new dict with new, potentially nested, key value pair
+
+    >>> purchase = {'name': 'Alice',
+    ...             'order': {'items': ['Apple', 'Orange'],
+    ...                       'costs': [0.50, 1.25]},
+    ...             'credit card': '5555-1234-1234-1234'}
+    >>> assoc_in(purchase, ['order', 'costs'], [0.25, 1.00]) # doctest: +SKIP
+    {'credit card': '5555-1234-1234-1234',
+     'name': 'Alice',
+     'purchase': {'costs': [0.25, 1.00], 'items': ['Apple', 'Orange']}}
+    """
+    return update_in(d, keys, lambda x: value, value, factory)
 
 
 def update_in(d, keys, func, default=None, factory=dict):

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -1,7 +1,7 @@
 from collections import defaultdict as _defaultdict
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
                              assoc, dissoc, keyfilter, valfilter, itemmap,
-                             itemfilter)
+                             itemfilter, assoc_in)
 from toolz.utils import raises
 from toolz.compatibility import PY3
 
@@ -100,6 +100,20 @@ class TestDict(object):
         d = D({'x': 1})
         oldd = d
         d2 = dissoc(d, 'x')
+        assert d is oldd
+        assert d2 is not oldd
+
+    def test_assoc_in(self):
+        D, kw = self.D, self.kw
+        assert assoc_in(D({"a": 1}), ["a"], 2, **kw) == D({"a": 2})
+        assert (assoc_in(D({"a": D({"b": 1})}), ["a", "b"], 2, **kw) ==
+                D({"a": D({"b": 2})}))
+        assert assoc_in(D({}), ["a", "b"], 1, **kw) == D({"a": D({"b": 1})})
+
+        # Verify immutability:
+        d = D({'x': 1})
+        oldd = d
+        d2 = assoc_in(d, ['x'], 2, **kw)
         assert d is oldd
         assert d2 is not oldd
 
@@ -236,4 +250,3 @@ class TestCustomMapping(TestDict):
     """
     D = CustomMapping
     kw = {'factory': lambda: CustomMapping()}
-


### PR DESCRIPTION
Hi everyone, thanks for making toolz, it is very elegant.

I think `assoc_in` should exist because it is a commonly used idiom when working with nested dictionaries. This doesn't fit the contribution guide of providing a significantly different functionality but it does provide what I think might be expected functionality. There's `update_in` and `get_in` to reach into nested dictionaries, but to do an `assoc_in` you have to figure out to call `update_in` with a noop function and a default value.

It's a wrapper around an existing function so it won't cause much maintenance overhead. Let me know what you think. Thanks again!