### PR TITLE
Better curry introspection

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,8 @@ omit =
     toolz/tests/test*
     toolz/*/tests/test*
     toolz/compatibility.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    pragma: py$MAJOR_PYTHON_VERSION no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
     - "pypy3"
 
 env:
-    - PEP8_IGNORE="E731,W503"
+    - PEP8_IGNORE="E731,W503,E402"
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
     - "3.4"
     - "3.5"
     - "pypy"
-    - "pypy3"
 
 env:
     - PEP8_IGNORE="E731,W503,E402"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 # require 100% coverage (not including test files) to pass Travis CI test
 # To skip pypy: - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then DOSTUFF ; fi
 script:
+    - export MAJOR_PYTHON_VERSION=`echo $TRAVIS_PYTHON_VERSION | cut -c 1`
     - coverage run --source=toolz $(which nosetests)
                    --with-doctest
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage report --show-missing --fail-under=100 ; fi

--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -1,7 +1,7 @@
-"""Internal module (i.e., not public) to support better introspection for curry
+"""Internal module for better introspection of builtins.
 
-The primary functions are ``is_valid_args``, ``is_partial_args``, and
-``has_unknown_args``.  Other functions in this module support these three.
+The main functions are ``is_builtin_valid_args``, ``is_builtin_partial_args``,
+and ``has_unknown_args``.  Other functions in this module support these three.
 
 Notably, we create a ``signatures`` registry to enable introspection of
 builtin functions in any Python version.  This includes builtins that

--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -1,0 +1,638 @@
+import functools
+import inspect
+import itertools
+import operator
+import sys
+
+from .compatibility import PY3
+
+if PY3:  # pragma: no cover
+    import builtins
+else:  # pragma: no cover
+    import __builtin__ as builtins
+
+module_info = {}
+
+module_info[builtins] = dict(
+    abs=[
+        lambda x: None],
+    all=[
+        lambda iterable: None],
+    any=[
+        lambda iterable: None],
+    apply=[
+        lambda object: None,
+        lambda object, args: None,
+        lambda object, args, kwargs: None],
+    ascii=[
+        lambda obj: None],
+    bin=[
+        lambda number: None],
+    bool=[
+        lambda x=False: None],
+    buffer=[
+        lambda object: None,
+        lambda object, offset: None,
+        lambda object, offset, size: None],
+    bytearray=[
+        lambda: None,
+        lambda int: None,
+        lambda string, encoding='utf8', errors='strict': None],
+    callable=[
+        lambda obj: None],
+    chr=[
+        lambda i: None],
+    classmethod=[
+        lambda function: None],
+    cmp=[
+        lambda x, y: None],
+    coerce=[
+        lambda x, y: None],
+    complex=[
+        lambda real=0, imag=0: None],
+    delattr=[
+        lambda obj, name: None],
+    dict=[
+        lambda **kwargs: None,
+        lambda mapping, **kwargs: None],
+    dir=[
+        lambda: None,
+        lambda object: None],
+    divmod=[
+        lambda x, y: None],
+    enumerate=[
+        (0, lambda iterable, start=0: None)],
+    eval=[
+        lambda source: None,
+        lambda source, globals: None,
+        lambda source, globals, locals: None],
+    execfile=[
+        lambda filename: None,
+        lambda filename, globals: None,
+        lambda filename, globals, locals: None],
+    file=[
+        (0, lambda name, mode='r', buffering=-1: None)],
+    filter=[
+        lambda function, iterable: None],
+    float=[
+        lambda x=0.0: None],
+    format=[
+        lambda value: None,
+        lambda value, format_spec: None],
+    frozenset=[
+        lambda: None,
+        lambda iterable: None],
+    getattr=[
+        lambda object, name: None,
+        lambda object, name, default: None],
+    globals=[
+        lambda: None],
+    hasattr=[
+        lambda obj, name: None],
+    hash=[
+        lambda obj: None],
+    hex=[
+        lambda number: None],
+    id=[
+        lambda obj: None],
+    input=[
+        lambda: None,
+        lambda prompt: None],
+    int=[
+        lambda x=0: None,
+        (0, lambda x, base=10: None)],
+    intern=[
+        lambda string: None],
+    isinstance=[
+        lambda obj, class_or_tuple: None],
+    issubclass=[
+        lambda cls, class_or_tuple: None],
+    iter=[
+        lambda iterable: None,
+        lambda callable, sentinel: None],
+    len=[
+        lambda obj: None],
+    list=[
+        lambda: None,
+        lambda iterable: None],
+    locals=[
+        lambda: None],
+    long=[
+        lambda x=0: None,
+        (0, lambda x, base=10: None)],
+    map=[
+        lambda func, sequence, *iterables: None],
+    memoryview=[
+        (0, lambda object: None)],
+    next=[
+        lambda iterator: None,
+        lambda iterator, default: None],
+    object=[
+        lambda: None],
+    oct=[
+        lambda number: None],
+    ord=[
+        lambda c: None],
+    pow=[
+        lambda x, y: None,
+        lambda x, y, z: None],
+    property=[
+        lambda fget=None, fset=None, fdel=None, doc=None: None],
+    range=[
+        lambda stop: None,
+        lambda start, stop: None,
+        lambda start, stop, step: None],
+    raw_input=[
+        lambda: None,
+        lambda prompt: None],
+    reduce=[
+        lambda function, sequence: None,
+        lambda function, sequence, initial: None],
+    reload=[
+        lambda module: None],
+    repr=[
+        lambda obj: None],
+    reversed=[
+        lambda sequence: None],
+    round=[
+        (0, lambda number, ndigits=0: None)],
+    set=[
+        lambda: None,
+        lambda iterable: None],
+    setattr=[
+        lambda obj, name, value: None],
+    slice=[
+        lambda stop: None,
+        lambda start, stop: None,
+        lambda start, stop, step: None],
+    staticmethod=[
+        lambda function: None],
+    sum=[
+        lambda iterable: None,
+        lambda iterable, start: None],
+    super=[
+        lambda type: None,
+        lambda type, obj: None],
+    tuple=[
+        lambda: None,
+        lambda iterable: None],
+    type=[
+        lambda object: None,
+        lambda name, bases, dict: None],
+    unichr=[
+        lambda i: None],
+    unicode=[
+        lambda object: None,
+        lambda string='', encoding='utf8', errors='strict': None],
+    vars=[
+        lambda: None,
+        lambda object: None],
+    xrange=[
+        lambda stop: None,
+        lambda start, stop: None,
+        lambda start, stop, step: None],
+    zip=[
+        lambda *iterables: None],
+)
+module_info[builtins]['exec'] = [
+    lambda source: None,
+    lambda source, globals: None,
+    lambda source, globals, locals: None]
+
+if PY3:  # pragma: no cover
+    module_info[builtins].update(
+        bytes=[
+            lambda: None,
+            lambda int: None,
+            lambda string, encoding='utf8', errors='strict': None],
+        compile=[
+            (0, lambda source, filename, mode, flags=0,
+                dont_inherit=False, optimize=-1: None)],
+        max=[
+            (1, lambda iterable: None, ('default', 'key',)),
+            (1, lambda arg1, arg2, *args: None, ('key',))],
+        min=[
+            (1, lambda iterable: None, ('default', 'key',)),
+            (1, lambda arg1, arg2, *args: None, ('key',))],
+        open=[
+            (0, lambda file, mode='r', buffering=-1, encoding=None,
+                errors=None, newline=None, closefd=True, opener=None: None)],
+        sorted=[
+            lambda iterable, key=None, reverse=False: None],
+        str=[
+            lambda object='', encoding='utf', errors='strict': None],
+    )
+    module_info[builtins]['print'] = [
+        (0, lambda *args: None, ('sep', 'end', 'file', 'flush',))]
+
+else:  # pragma: no cover
+    module_info[builtins].update(
+        bytes=[
+            lambda object='': None],
+        compile=[
+            (0, lambda source, filename, mode, flags=0,
+                dont_inherit=False: None)],
+        max=[
+            (1, lambda iterable, *args: None, ('key',))],
+        min=[
+            (1, lambda iterable, *args: None, ('key',))],
+        open=[
+            (0, lambda file, mode='r', buffering=-1: None)],
+        sorted=[
+            lambda iterable, cmp=None, key=None, reverse=False: None],
+        str=[
+            lambda object='': None],
+    )
+    module_info[builtins]['print'] = [
+        (0, lambda *args: None, ('sep', 'end', 'file',))]
+
+module_info[functools] = dict(
+    cmp_to_key=[
+        (0, lambda mycmp: None)],
+    partial=[
+        lambda func, *args, **kwargs: None],
+    partialmethod=[
+        lambda func, *args, **kwargs: None],
+    reduce=[
+        lambda function, sequence: None,
+        lambda function, sequence, initial: None],
+)
+
+module_info[itertools] = dict(
+    accumulate=[
+        (0, lambda iterable, func=None: None)],
+    chain=[
+        lambda *iterables: None],
+    combinations=[
+        (0, lambda iterable, r: None)],
+    combinations_with_replacement=[
+        (0, lambda iterable, r: None)],
+    compress=[
+        (0, lambda data, selectors: None)],
+    count=[
+        lambda start=0, step=1: None],
+    cycle=[
+        lambda iterable: None],
+    dropwhile=[
+        lambda predicate, iterable: None],
+    filterfalse=[
+        lambda function, sequence: None],
+    groupby=[
+        (0, lambda iterable, key=None: None)],
+    ifilter=[
+        lambda function, sequence: None],
+    ifilterfalse=[
+        lambda function, sequence: None],
+    imap=[
+        lambda func, sequence, *iterables: None],
+    islice=[
+        lambda iterable, stop: None,
+        lambda iterable, start, stop: None,
+        lambda iterable, start, stop, step: None],
+    izip=[
+        lambda *iterables: None],
+    izip_longest=[
+        (0, lambda *iterables: None, ('fillvalue',))],
+    permutations=[
+        (0, lambda iterable, r=0: None)],
+    repeat=[
+        (0, lambda object, times=0: None)],
+    starmap=[
+        lambda function, sequence: None],
+    takewhile=[
+        lambda predicate, iterable: None],
+    tee=[
+        lambda iterable: None,
+        lambda iterable, n: None],
+    zip_longest=[
+        (0, lambda *iterables: None, ('fillvalue',))],
+)
+
+if PY3:  # pragma: no cover
+    module_info[itertools].update(
+        product=[
+            (0, lambda *iterables: None, ('repeat',))],
+    )
+else:  # pragma: no cover
+    module_info[itertools].update(
+        product=[
+            lambda *iterables: None],
+    )
+
+module_info[operator] = dict(
+    __abs__=[
+        lambda a: None],
+    __add__=[
+        lambda a, b: None],
+    __and__=[
+        lambda a, b: None],
+    __concat__=[
+        lambda a, b: None],
+    __contains__=[
+        lambda a, b: None],
+    __delitem__=[
+        lambda a, b: None],
+    __delslice__=[
+        lambda a, b, c: None],
+    __div__=[
+        lambda a, b: None],
+    __eq__=[
+        lambda a, b: None],
+    __floordiv__=[
+        lambda a, b: None],
+    __ge__=[
+        lambda a, b: None],
+    __getitem__=[
+        lambda a, b: None],
+    __getslice__=[
+        lambda a, b, c: None],
+    __gt__=[
+        lambda a, b: None],
+    __iadd__=[
+        lambda a, b: None],
+    __iand__=[
+        lambda a, b: None],
+    __iconcat__=[
+        lambda a, b: None],
+    __idiv__=[
+        lambda a, b: None],
+    __ifloordiv__=[
+        lambda a, b: None],
+    __ilshift__=[
+        lambda a, b: None],
+    __imatmul__=[
+        lambda a, b: None],
+    __imod__=[
+        lambda a, b: None],
+    __imul__=[
+        lambda a, b: None],
+    __index__=[
+        lambda a: None],
+    __inv__=[
+        lambda a: None],
+    __invert__=[
+        lambda a: None],
+    __ior__=[
+        lambda a, b: None],
+    __ipow__=[
+        lambda a, b: None],
+    __irepeat__=[
+        lambda a, b: None],
+    __irshift__=[
+        lambda a, b: None],
+    __isub__=[
+        lambda a, b: None],
+    __itruediv__=[
+        lambda a, b: None],
+    __ixor__=[
+        lambda a, b: None],
+    __le__=[
+        lambda a, b: None],
+    __lshift__=[
+        lambda a, b: None],
+    __lt__=[
+        lambda a, b: None],
+    __matmul__=[
+        lambda a, b: None],
+    __mod__=[
+        lambda a, b: None],
+    __mul__=[
+        lambda a, b: None],
+    __ne__=[
+        lambda a, b: None],
+    __neg__=[
+        lambda a: None],
+    __not__=[
+        lambda a: None],
+    __or__=[
+        lambda a, b: None],
+    __pos__=[
+        lambda a: None],
+    __pow__=[
+        lambda a, b: None],
+    __repeat__=[
+        lambda a, b: None],
+    __rshift__=[
+        lambda a, b: None],
+    __setitem__=[
+        lambda a, b, c: None],
+    __setslice__=[
+        lambda a, b, c, d: None],
+    __sub__=[
+        lambda a, b: None],
+    __truediv__=[
+        lambda a, b: None],
+    __xor__=[
+        lambda a, b: None],
+    _abs=[
+        lambda x: None],
+    _compare_digest=[
+        lambda a, b: None],
+    abs=[
+        lambda a: None],
+    add=[
+        lambda a, b: None],
+    and_=[
+        lambda a, b: None],
+    attrgetter=[
+        lambda attr, *args: None],
+    concat=[
+        lambda a, b: None],
+    contains=[
+        lambda a, b: None],
+    countOf=[
+        lambda a, b: None],
+    delitem=[
+        lambda a, b: None],
+    delslice=[
+        lambda a, b, c: None],
+    div=[
+        lambda a, b: None],
+    eq=[
+        lambda a, b: None],
+    floordiv=[
+        lambda a, b: None],
+    ge=[
+        lambda a, b: None],
+    getitem=[
+        lambda a, b: None],
+    getslice=[
+        lambda a, b, c: None],
+    gt=[
+        lambda a, b: None],
+    iadd=[
+        lambda a, b: None],
+    iand=[
+        lambda a, b: None],
+    iconcat=[
+        lambda a, b: None],
+    idiv=[
+        lambda a, b: None],
+    ifloordiv=[
+        lambda a, b: None],
+    ilshift=[
+        lambda a, b: None],
+    imatmul=[
+        lambda a, b: None],
+    imod=[
+        lambda a, b: None],
+    imul=[
+        lambda a, b: None],
+    index=[
+        lambda a: None],
+    indexOf=[
+        lambda a, b: None],
+    inv=[
+        lambda a: None],
+    invert=[
+        lambda a: None],
+    ior=[
+        lambda a, b: None],
+    ipow=[
+        lambda a, b: None],
+    irepeat=[
+        lambda a, b: None],
+    irshift=[
+        lambda a, b: None],
+    is_=[
+        lambda a, b: None],
+    is_not=[
+        lambda a, b: None],
+    isCallable=[
+        lambda a: None],
+    isMappingType=[
+        lambda a: None],
+    isNumberType=[
+        lambda a: None],
+    isSequenceType=[
+        lambda a: None],
+    isub=[
+        lambda a, b: None],
+    itemgetter=[
+        lambda item, *args: None],
+    itruediv=[
+        lambda a, b: None],
+    ixor=[
+        lambda a, b: None],
+    le=[
+        lambda a, b: None],
+    length_hint=[
+        lambda obj: None,
+        lambda obj, default: None],
+    lshift=[
+        lambda a, b: None],
+    lt=[
+        lambda a, b: None],
+    matmul=[
+        lambda a, b: None],
+    methodcaller=[
+        lambda name, *args, **kwargs: None],
+    mod=[
+        lambda a, b: None],
+    mul=[
+        lambda a, b: None],
+    ne=[
+        lambda a, b: None],
+    neg=[
+        lambda a: None],
+    not_=[
+        lambda a: None],
+    or_=[
+        lambda a, b: None],
+    pos=[
+        lambda a: None],
+    pow=[
+        lambda a, b: None],
+    repeat=[
+        lambda a, b: None],
+    rshift=[
+        lambda a, b: None],
+    sequenceIncludes=[
+        lambda a, b: None],
+    setitem=[
+        lambda a, b, c: None],
+    setslice=[
+        lambda a, b, c, d: None],
+    sub=[
+        lambda a, b: None],
+    truediv=[
+        lambda a, b: None],
+    truth=[
+        lambda a: None],
+    xor=[
+        lambda a, b: None],
+)
+
+if PY3:  # pragma: no cover
+    def num_pos_args(func):
+        sig = inspect.signature(func)
+        return sum(1 for x in sig.parameters.values()
+                   if x.kind is x.POSITIONAL_OR_KEYWORD and
+                   x.default is x.empty)
+
+else:  # pragma: no cover
+    def num_pos_args(func):
+        spec = inspect.getargspec(func)
+        if spec.defaults:
+            return len(spec.args) - len(spec.defaults)
+        return len(spec.args)
+
+
+def expand_sig(sig):
+    if isinstance(sig, tuple):
+        if len(sig) == 3:
+            assert isinstance(sig[-1], tuple)
+            return sig
+        num_pos_only, func = sig
+    else:
+        func = sig
+        num_pos_only = num_pos_args(func)
+    return (num_pos_only, func, ())
+
+
+signatures = {}
+for module, info in module_info.items():
+    for name, sigs in info.items():
+        if hasattr(module, name):
+            new_sigs = tuple(expand_sig(sig) for sig in sigs)
+            signatures[getattr(module, name)] = new_sigs
+
+
+def check_valid(sig, args, kwargs):
+    num_pos_only, func, keyword_only = sig
+    if len(args) < num_pos_only:
+        return False
+    if keyword_only:
+        kwargs = dict(kwargs)
+        for item in keyword_only:
+            kwargs.pop(item, None)
+    return is_valid_args(func, args, kwargs)
+
+
+def check_partial(sig, args, kwargs):
+    num_pos_only, func, keyword_only = sig
+    if len(args) < num_pos_only:
+        pad = (None,) * (num_pos_only - len(args))
+        args = args + pad
+    if keyword_only:
+        kwargs = dict(kwargs)
+        for item in keyword_only:
+            kwargs.pop(item, None)
+    return is_partial_args(func, args, kwargs)
+
+
+def is_builtin_valid_args(func, args, kwargs):
+    if func not in signatures:
+        return None
+    sigs = signatures[func]
+    return any(check_valid(sig, args, kwargs) for sig in sigs)
+
+
+def is_builtin_partial_args(func, args, kwargs):
+    if func not in signatures:
+        return None
+    sigs = signatures[func]
+    return any(check_partial(sig, args, kwargs) for sig in sigs)
+
+
+from .functoolz import is_valid_args, is_partial_args

--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -645,7 +645,11 @@ if PY3:  # pragma: py2 no cover
             return True
         except TypeError:
             return False
-        return any(x.kind == x.VAR_POSITIONAL for x in sig.parameters.values())
+        try:
+            return any(x.kind == x.VAR_POSITIONAL
+                       for x in sig.parameters.values())
+        except AttributeError:  # pragma: no cover
+            return False
 
 else:  # pragma: py3 no cover
     def has_unknown_args(func):

--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -635,18 +635,22 @@ def is_builtin_partial_args(func, args, kwargs):
     return any(check_partial(sig, args, kwargs) for sig in sigs)
 
 
-def has_unknown_args(func):
-    if func in signatures:
-        return False
-    if PY3:  # pragma: py2 no cover
+if PY3:  # pragma: py2 no cover
+    def has_unknown_args(func):
+        if func in signatures:
+            return False
         try:
             sig = inspect.signature(func)
-        except ValueError:  # pragma: no cover
+        except ValueError:
             return True
         except TypeError:
             return False
         return any(x.kind == x.VAR_POSITIONAL for x in sig.parameters.values())
-    else:  # pragma: py3 no cover
+
+else:  # pragma: py3 no cover
+    def has_unknown_args(func):
+        if func in signatures:
+            return False
         try:
             spec = inspect.getargspec(func)
         except TypeError:

--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -1,3 +1,16 @@
+"""Internal module (i.e., not public) to support better introspection for curry
+
+The primary functions are ``is_valid_args``, ``is_partial_args``, and
+``has_unknown_args``.  Other functions in this module support these three.
+
+Notably, we create a ``signatures`` registry to enable introspection of
+builtin functions in any Python version.  This includes builtins that
+have more than one valid signature.
+
+Everything in this module should be regarded as implementation details.
+Users should try to not use this module directly.
+
+"""
 import functools
 import inspect
 import itertools
@@ -10,6 +23,21 @@ if PY3:  # pragma: py2 no cover
     import builtins
 else:  # pragma: py3 no cover
     import __builtin__ as builtins
+
+# We mock builtin callables using lists of tuples with lambda functions.
+#
+# The tuple spec is (num_position_args, lambda_func, keyword_only_args).
+#
+#   num_position_args:
+#       - The number of positional-only arguments.  If not specified,
+#         all positional arguments are considered positional-only.
+#
+#   lambda_func:
+#       - lambda function that matches a signature of a builtin, but does
+#         not include keyword-only arguments.
+#
+#   keyword_only_args: (optional)
+#       - Tuple of keyword-only argumemts.
 
 module_info = {}
 

--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -1,6 +1,8 @@
 import operator
 import sys
 PY3 = sys.version_info[0] > 2
+PY34 = sys.version_info[0] == 3 and sys.version_info[1] == 4
+PYPY = hasattr(sys, 'pypy_version_info')
 
 __all__ = ('PY3', 'map', 'filter', 'range', 'zip', 'reduce', 'zip_longest',
            'iteritems', 'iterkeys', 'itervalues', 'filterfalse')

--- a/toolz/curried/exceptions.py
+++ b/toolz/curried/exceptions.py
@@ -5,19 +5,13 @@ __all__ = ['merge_with', 'merge']
 
 
 @toolz.curry
-def merge_with(fn, *dicts, **kwargs):
-    if len(dicts) == 0:
-        raise TypeError()
-    else:
-        return toolz.merge_with(fn, *dicts, **kwargs)
+def merge_with(func, d, *dicts, **kwargs):
+    return toolz.merge_with(func, d, *dicts, **kwargs)
 
 
 @toolz.curry
-def merge(*dicts, **kwargs):
-    if len(dicts) == 0:
-        raise TypeError()
-    else:
-        return toolz.merge(*dicts, **kwargs)
+def merge(d, *dicts, **kwargs):
+    return toolz.merge(d, *dicts, **kwargs)
 
 merge_with.__doc__ = toolz.merge_with.__doc__
 merge.__doc__ = toolz.merge.__doc__

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -148,6 +148,7 @@ class curry(object):
 
         self.__doc__ = getattr(func, '__doc__', None)
         self.__name__ = getattr(func, '__name__', '<curry>')
+        self._sigspec = None
 
     @property
     def func(self):
@@ -197,7 +198,10 @@ class curry(object):
         args = self.args + args
         if self.keywords:
             kwargs = dict(self.keywords, **kwargs)
-        sigspec = _signature_or_spec(func)
+        if self._sigspec is None:
+            sigspec = self._sigspec = _signature_or_spec(func)
+        else:
+            sigspec = self._sigspec
         return (
             (
                 not is_valid_args(func, args, kwargs, sigspec=sigspec) or

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -685,6 +685,11 @@ def is_valid_args(func, args, kwargs):
     Many builtins in the standard library are also supported.
     """
     if PY3:  # pragma: no cover
+        if sys.version_info[1] == 4:
+            # Python 3.4 may lie, so use our registry for builtins instead
+            val = _is_builtin_valid_args(func, args, kwargs)
+            if val is not None:
+                return val
         try:
             sig = inspect.signature(func)
         except ValueError:
@@ -760,6 +765,11 @@ def is_partial_args(func, args, kwargs):
     Many builtins in the standard library are also supported.
     """
     if PY3:  # pragma: no cover
+        if sys.version_info[1] == 4:
+            # Python 3.4 may lie, so use our registry for builtins instead
+            val = _is_builtin_partial_args(func, args, kwargs)
+            if val is not None:
+                return val
         try:
             sig = inspect.signature(func)
         except ValueError:

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 from textwrap import dedent
 import sys
 
-from .compatibility import PY3
+from .compatibility import PY3, PY34, PYPY
 
 __all__ = ('identity', 'thread_first', 'thread_last', 'memoize', 'compose',
            'pipe', 'complement', 'juxt', 'do', 'curry', 'flip', 'excepts')
@@ -685,7 +685,7 @@ def is_valid_args(func, args, kwargs):
     Many builtins in the standard library are also supported.
     """
     if PY3:  # pragma: no cover
-        if sys.version_info[1] == 4:
+        if PY34 or PYPY:
             # Python 3.4 may lie, so use our registry for builtins instead
             val = _is_builtin_valid_args(func, args, kwargs)
             if val is not None:
@@ -702,6 +702,10 @@ def is_valid_args(func, args, kwargs):
             return False
         return True
     else:  # pragma: no cover
+        if PYPY:
+            val = _is_builtin_valid_args(func, args, kwargs)
+            if val is not None:
+                return val
         try:
             spec = inspect.getargspec(func)
         except TypeError:
@@ -765,7 +769,7 @@ def is_partial_args(func, args, kwargs):
     Many builtins in the standard library are also supported.
     """
     if PY3:  # pragma: no cover
-        if sys.version_info[1] == 4:
+        if PY34 or PYPY:
             # Python 3.4 may lie, so use our registry for builtins instead
             val = _is_builtin_partial_args(func, args, kwargs)
             if val is not None:
@@ -782,6 +786,10 @@ def is_partial_args(func, args, kwargs):
             return False
         return True
     else:  # pragma: no cover
+        if PYPY:
+            val = _is_builtin_partial_args(func, args, kwargs)
+            if val is not None:
+                return val
         try:
             spec = inspect.getargspec(func)
         except TypeError:

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -672,7 +672,7 @@ if PY3:  # pragma: py2 no cover
             return False
         try:
             sig.bind(*args, **kwargs)
-        except TypeError:
+        except (TypeError, AttributeError):
             return False
         return True
 
@@ -759,7 +759,7 @@ if PY3:  # pragma: py2 no cover
             return False
         try:
             sig.bind_partial(*args, **kwargs)
-        except TypeError:
+        except (TypeError, AttributeError):
             return False
         return True
 

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -730,14 +730,15 @@ def is_valid_args(func, args, kwargs):
 
         # Convert call to use positional arguments
         args = args + tuple(kwargs.pop(key) for key in spec.args[len(args):])
-        if spec.keywords:
-            kwargs.pop('func', None)
 
-        try:
-            inspect.getcallargs(func, *args, **kwargs)
-        except TypeError:
+        if (
+            not spec.keywords and kwargs or
+            not spec.varargs and len(args) > len(spec.args) or
+            set(spec.args[:len(args)]) & set(kwargs)
+        ):
             return False
-        return True
+        else:
+            return True
 
 
 def is_partial_args(func, args, kwargs):
@@ -814,14 +815,15 @@ def is_partial_args(func, args, kwargs):
 
         # Convert call to use positional arguments
         args = args + tuple(kwargs.pop(key) for key in spec.args[len(args):])
-        if spec.keywords:
-            kwargs.pop('func', None)
 
-        try:
-            inspect.getcallargs(func, *args, **kwargs)
-        except TypeError:
+        if (
+            not spec.keywords and kwargs or
+            not spec.varargs and len(args) > len(spec.args) or
+            set(spec.args[:len(args)]) & set(kwargs)
+        ):
             return False
-        return True
+        else:
+            return True
 
 
 from ._signatures import (is_builtin_valid_args as _is_builtin_valid_args,

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -453,6 +453,25 @@ def test_curry_bind():
     assert add.bind(x=10).bind(y=20)() == add(10, 20)
 
 
+def test_curry_unknown_args():
+    def add3(x, y, z):
+        return x + y + z
+
+    @curry
+    def f(*args):
+        return add3(*args)
+
+    assert f()(1)(2)(3) == 6
+    assert f(1)(2)(3) == 6
+    assert f(1, 2)(3) == 6
+    assert f(1, 2, 3) == 6
+    assert f(1, 2)(3, 4) == f(1, 2, 3, 4)
+
+
+def test_curry_bad_types():
+    assert raises(TypeError, lambda: curry(1))
+
+
 def test_compose():
     assert compose()(0) == 0
     assert compose(inc)(0) == 1

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -472,6 +472,31 @@ def test_curry_bad_types():
     assert raises(TypeError, lambda: curry(1))
 
 
+def test_curry_subclassable():
+    class mycurry(curry):
+        pass
+
+    add = mycurry(lambda x, y: x+y)
+    assert isinstance(add, curry)
+    assert isinstance(add, mycurry)
+    assert isinstance(add(1), mycurry)
+    assert isinstance(add()(1), mycurry)
+    assert add(1)(2) == 3
+
+    # Should we make `_should_curry` public?
+    """
+    class curry2(curry):
+        def _should_curry(self, args, kwargs, exc=None):
+            return len(self.args) + len(args) < 2
+
+    add = curry2(lambda x, y: x+y)
+    assert isinstance(add(1), curry2)
+    assert add(1)(2) == 3
+    assert isinstance(add(1)(x=2), curry2)
+    assert raises(TypeError, lambda: add(1)(x=2)(3))
+    """
+
+
 def test_compose():
     assert compose()(0) == 0
     assert compose(inc)(0) == 1

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -1,0 +1,199 @@
+import sys
+from toolz.functoolz import is_valid_args, is_partial_args
+from toolz.compatibility import PY3
+from toolz.utils import raises
+
+
+def make_func(param_string, raise_if_called=True):
+    if not param_string.startswith('('):
+        param_string = '(%s)' % param_string
+    if raise_if_called:
+        body = 'raise ValueError("function should not be called")'
+    else:
+        body = 'return True'
+    d = {}
+    exec('def func%s:\n    %s' % (param_string, body), globals(), d)
+    return d['func']
+
+
+def test_make_func():
+    f = make_func('')
+    assert raises(ValueError, lambda: f())
+    assert raises(TypeError, lambda: f(1))
+
+    f = make_func('', raise_if_called=False)
+    assert f()
+    assert raises(TypeError, lambda: f(1))
+
+    f = make_func('x, y=1', raise_if_called=False)
+    assert f(1)
+    assert f(x=1)
+    assert f(1, 2)
+    assert f(x=1, y=2)
+    assert raises(TypeError, lambda: f(1, 2, 3))
+
+    f = make_func('(x, y=1)', raise_if_called=False)
+    assert f(1)
+    assert f(x=1)
+    assert f(1, 2)
+    assert f(x=1, y=2)
+    assert raises(TypeError, lambda: f(1, 2, 3))
+
+
+def test_is_valid(check_valid=is_valid_args, incomplete=False):
+    orig_check_valid = check_valid
+    check_valid = lambda func, *args, **kwargs: orig_check_valid(func, args, kwargs)
+
+    f = make_func('')
+    assert check_valid(f)
+    assert check_valid(f, 1) is False
+    assert check_valid(f, x=1) is False
+
+    f = make_func('x')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1)
+    assert check_valid(f, x=1)
+    assert check_valid(f, 1, x=2) is False
+    assert check_valid(f, 1, y=2) is False
+    assert check_valid(f, 1, 2) is False
+    assert check_valid(f, x=1, y=2) is False
+
+    f = make_func('x=1')
+    assert check_valid(f)
+    assert check_valid(f, 1)
+    assert check_valid(f, x=1)
+    assert check_valid(f, 1, x=2) is False
+    assert check_valid(f, 1, y=2) is False
+    assert check_valid(f, 1, 2) is False
+    assert check_valid(f, x=1, y=2) is False
+
+    f = make_func('*args')
+    assert check_valid(f)
+    assert check_valid(f, 1)
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, x=1) is False
+
+    f = make_func('**kwargs')
+    assert check_valid(f)
+    assert check_valid(f, x=1)
+    assert check_valid(f, x=1, y=2)
+    assert check_valid(f, 1) is False
+
+    f = make_func('x, *args')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1)
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, x=1)
+    assert check_valid(f, 1, x=1) is False
+    assert check_valid(f, 1, y=1) is False
+
+    f = make_func('x, y=1, **kwargs')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1)
+    assert check_valid(f, x=1)
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, x=1, y=2, z=3)
+    assert check_valid(f, 1, 2, y=3) is False
+
+    f = make_func('a, b, c=3, d=4')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1) is incomplete
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, 1, c=3) is incomplete
+    assert check_valid(f, 1, e=3) is False
+    assert check_valid(f, 1, 2, e=3) is False
+    assert check_valid(f, 1, 2, b=3) is False
+
+
+def test_is_valid_py3(check_valid=is_valid_args, incomplete=False):
+    if not PY3:
+        return
+    orig_check_valid = check_valid
+    check_valid = lambda func, *args, **kwargs: orig_check_valid(func, args, kwargs)
+
+    f = make_func('x, *, y=1')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1)
+    assert check_valid(f, x=1)
+    assert check_valid(f, 1, y=2)
+    assert check_valid(f, 1, 2) is False
+    assert check_valid(f, 1, z=2) is False
+
+    f = make_func('x, *args, y=1')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1)
+    assert check_valid(f, x=1)
+    assert check_valid(f, 1, y=2)
+    assert check_valid(f, 1, 2, y=2)
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, 1, z=2) is False
+
+    f = make_func('*, y=1')
+    assert check_valid(f)
+    assert check_valid(f, 1) is False
+    assert check_valid(f, y=1)
+    assert check_valid(f, z=1) is False
+
+    f = make_func('x, *, y')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1) is incomplete
+    assert check_valid(f, x=1) is incomplete
+    assert check_valid(f, 1, y=2)
+    assert check_valid(f, x=1, y=2)
+    assert check_valid(f, 1, 2) is False
+    assert check_valid(f, 1, z=2) is False
+    assert check_valid(f, 1, y=1, z=2) is False
+
+    f = make_func('x=1, *, y, z=3')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1, z=3) is incomplete
+    assert check_valid(f, y=2)
+    assert check_valid(f, 1, y=2)
+    assert check_valid(f, x=1, y=2)
+    assert check_valid(f, x=1, y=2, z=3)
+    assert check_valid(f, 1, x=1, y=2) is False
+    assert check_valid(f, 1, 3, y=2) is False
+
+    f = make_func('w, x=2, *args, y, z=4')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1) is incomplete
+    assert check_valid(f, 1, y=3)
+
+    f = make_func('a, b, c=3, d=4, *args, e=5, f=6, g, h')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1) is incomplete
+    assert check_valid(f, 1, 2) is incomplete
+    assert check_valid(f, 1, 2, g=7) is incomplete
+    assert check_valid(f, 1, 2, g=7, h=8)
+    assert check_valid(f, 1, 2, 3, 4, 5, 6, 7, 8, 9) is incomplete
+
+    f = make_func('a: int, b: float')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1) is incomplete
+    assert check_valid(f, b=1) is incomplete
+    assert check_valid(f, 1, 2)
+
+    f = make_func('(a: int, b: float) -> float')
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1) is incomplete
+    assert check_valid(f, b=1) is incomplete
+    assert check_valid(f, 1, 2)
+
+
+def test_is_partial():
+    test_is_valid(check_valid=is_partial_args, incomplete=True)
+    test_is_valid_py3(check_valid=is_partial_args, incomplete=True)
+
+
+def test_func_keyword():
+    def f(func=None):
+        pass
+    assert is_valid_args(f, (), {})
+    assert is_valid_args(f, (None,), {})
+    assert is_valid_args(f, (), {'func': None})
+    assert is_valid_args(f, (None,), {'func': None}) is False
+    assert is_partial_args(f, (), {})
+    assert is_partial_args(f, (None,), {})
+    assert is_partial_args(f, (), {'func': None})
+    assert is_partial_args(f, (None,), {'func': None}) is False
+

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -1,5 +1,6 @@
 import sys
 from toolz.functoolz import is_valid_args, is_partial_args
+from toolz._signatures import has_unknown_args
 from toolz.compatibility import PY3
 from toolz.utils import raises
 
@@ -104,6 +105,8 @@ def test_is_valid(check_valid=is_valid_args, incomplete=False):
     assert check_valid(f, 1, 2, e=3) is False
     assert check_valid(f, 1, 2, b=3) is False
 
+    assert check_valid(1) is False
+
 
 def test_is_valid_py3(check_valid=is_valid_args, incomplete=False):
     if not PY3:
@@ -196,4 +199,16 @@ def test_func_keyword():
     assert is_partial_args(f, (None,), {})
     assert is_partial_args(f, (), {'func': None})
     assert is_partial_args(f, (None,), {'func': None}) is False
+
+
+def test_has_unknown_args():
+    assert has_unknown_args(1) is False
+    assert has_unknown_args(map) is False
+    assert has_unknown_args(make_func('')) is False
+    assert has_unknown_args(make_func('x, y, z')) is False
+    assert has_unknown_args(make_func('*args'))
+    assert has_unknown_args(make_func('**kwargs')) is False
+    assert has_unknown_args(make_func('x, y, *args, **kwargs'))
+    assert has_unknown_args(make_func('x, y, z=1')) is False
+    assert has_unknown_args(make_func('x, y, z=1, **kwargs')) is False
 

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -182,6 +182,19 @@ def test_is_valid_py3(check_valid=is_valid_args, incomplete=False):
     assert check_valid(f, b=1) is incomplete
     assert check_valid(f, 1, 2)
 
+    f.__signature__ = 34
+    assert check_valid(f) is False
+
+    class RaisesValueError(object):
+        def __call__(self):
+            pass
+        @property
+        def __signature__(self):
+            raise ValueError('Testing Python 3.4')
+
+    f = RaisesValueError()
+    assert check_valid(f) is None
+
 
 def test_is_partial():
     test_is_valid(check_valid=is_partial_args, incomplete=True)
@@ -211,4 +224,19 @@ def test_has_unknown_args():
     assert has_unknown_args(make_func('x, y, *args, **kwargs'))
     assert has_unknown_args(make_func('x, y, z=1')) is False
     assert has_unknown_args(make_func('x, y, z=1, **kwargs')) is False
+
+    if PY3:
+        f = make_func('*args')
+        f.__signature__ = 34
+        assert has_unknown_args(f) is False
+
+        class RaisesValueError(object):
+            def __call__(self):
+                pass
+            @property
+            def __signature__(self):
+                raise ValueError('Testing Python 3.4')
+
+        f = RaisesValueError()
+        assert has_unknown_args(f)
 

--- a/toolz/tests/test_signatures.py
+++ b/toolz/tests/test_signatures.py
@@ -1,3 +1,4 @@
+import functools
 import sys
 from toolz._signatures import (builtins, is_builtin_valid_args,
                                is_builtin_partial_args)
@@ -66,6 +67,13 @@ def test_is_valid(check_valid=is_builtin_valid_args, incomplete=False):
     assert check_valid(f, 1, 2, 3)
     assert check_valid(f, 1, 2, step=3) is False
     assert check_valid(f, 1, 2, 3, 4) is False
+
+    f = functools.partial
+    assert orig_check_valid(f, (), {}) is incomplete
+    assert orig_check_valid(f, (), {'func': 1}) is incomplete
+    assert orig_check_valid(f, (1,), {})
+    assert orig_check_valid(f, (1,), {'func': 1})
+    assert orig_check_valid(f, (1, 2), {})
 
 
 def test_is_partial():

--- a/toolz/tests/test_signatures.py
+++ b/toolz/tests/test_signatures.py
@@ -1,0 +1,73 @@
+import sys
+from toolz._signatures import (builtins, is_builtin_valid_args,
+                               is_builtin_partial_args)
+from toolz.compatibility import PY3
+from toolz.utils import raises
+
+
+def test_is_valid(check_valid=is_builtin_valid_args, incomplete=False):
+    orig_check_valid = check_valid
+    check_valid = lambda func, *args, **kwargs: orig_check_valid(func, args, kwargs)
+
+    assert check_valid(lambda x: None) is None
+
+    f = builtins.abs
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1)
+    assert check_valid(f, x=1) is False
+    assert check_valid(f, 1, 2) is False
+
+    f = builtins.complex
+    assert check_valid(f)
+    assert check_valid(f, 1)
+    assert check_valid(f, real=1)
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, 1, imag=2)
+    assert check_valid(f, 1, real=2) is False
+    assert check_valid(f, 1, 2, 3) is False
+    assert check_valid(f, 1, 2, imag=3) is False
+
+    f = builtins.int
+    assert check_valid(f)
+    assert check_valid(f, 1)
+    assert check_valid(f, x=1)
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, 1, base=2)
+    assert check_valid(f, x=1, base=2)
+    assert check_valid(f, base=2) is incomplete
+    assert check_valid(f, 1, 2, 3) is False
+
+    f = builtins.map
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1) is incomplete
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, 1, 2, 3)
+    assert check_valid(f, 1, 2, 3, 4)
+
+    f = builtins.min
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1)
+    assert check_valid(f, iterable=1) is False
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, 1, 2, 3)
+    assert check_valid(f, key=None) is incomplete
+    assert check_valid(f, 1, key=None)
+    assert check_valid(f, 1, 2, key=None)
+    assert check_valid(f, 1, 2, 3, key=None)
+    assert check_valid(f, key=None, default=None) is (PY3 and incomplete)
+    assert check_valid(f, 1, key=None, default=None) is PY3
+    assert check_valid(f, 1, 2, key=None, default=None) is False
+    assert check_valid(f, 1, 2, 3, key=None, default=None) is False
+
+    f = builtins.range
+    assert check_valid(f) is incomplete
+    assert check_valid(f, 1)
+    assert check_valid(f, 1, 2)
+    assert check_valid(f, 1, 2, 3)
+    assert check_valid(f, 1, 2, step=3) is False
+    assert check_valid(f, 1, 2, 3, 4) is False
+
+
+def test_is_partial():
+    test_is_valid(check_valid=is_builtin_partial_args, incomplete=True)
+


### PR DESCRIPTION
Much better function introspection for `curry`.  This is my attempt to "solve" introspection for `curry` once and for all.

The heavy-lifters are `inspect.getargspec` for Python 2 and `inspect.signature` for Python 3.  We use these in our new functions `functoolz.is_valid_args` and `functoolz.is_partial_args`, which determine via introspection whether a function call is valid or incomplete with the possibility of becoming valid.

Support for many more builtins was added.  We maintain a registry of valid signatures in "_signatures.py" for `builtins`, `functools`, `itertools`, and `operator` modules.  I don't know how to feel about this, but it's done, so why argue?

Added `call` and `bind` methods to `curry`.

Removed `_num_required_args` as it is no longer needed.

This is a WIP and is based on discussions and suggestions from several issues.  I'll xref the relevant issues and PRs and give a more thorough discussion of the current PR a little later.  I need a break.  This was as much work as expected, but I hope it's worth it!

It appears we can support Python 2.7, 3,3, 3.4 and 3.5.  More tests are encouraged.  We can probably support Python 2.6 by not using `inspect.getcallargs`, but I'd be okay with dropping 2.6 (it's old!).

I don't know what to do about `pypy`.  IMHO, `pypy` failures should be fixed upstream in `pypy`.  We should probably drop `pypy3` support until it mirrors at least Python 3.3 (right now it's Python 3.2, which we don't support).
 _**edit** Tests now pass for Python 2.6 and pypy.  pypy3 does not have `inspect.signature`, so we can no longer support it._