### PR TITLE
Fix extra space in test_peek

### DIFF
--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -471,7 +471,7 @@ def test_topk_is_stable():
 
 def test_peek():
     alist = ["Alice", "Bob", "Carol"]
-    element, blist  = peek(alist)
+    element, blist = peek(alist)
     element == alist[0]
     assert list(blist) == alist
 


### PR DESCRIPTION
There is a an extra space before an operator in the test ``test_itertoolz/test_peek``. 
I hated to create a pull request just for this but, I figured if anyone else is using pylint they will be happy to see it removed.