### PR TITLE
More introspection

### DIFF
--- a/toolz/__init__.py
+++ b/toolz/__init__.py
@@ -17,4 +17,6 @@ sorted = sorted
 # Aliases
 comp = compose
 
+functoolz._sigs.create_signature_registry()
+
 __version__ = '0.7.4'

--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -11,13 +11,11 @@ modules.  More can be added as requested.  We don't guarantee full coverage.
 
 Everything in this module should be regarded as implementation details.
 Users should try to not use this module directly.
-
 """
 import functools
 import inspect
 import itertools
 import operator
-import sys
 
 from .compatibility import PY3
 from .functoolz import (is_partial_args, is_arity, has_varargs,
@@ -622,14 +620,14 @@ module_info['toolz.functoolz'] = dict(
 )
 
 if PY3:  # pragma: py2 no cover
-    def num_pos_args(func, sigspec):
-        """Return the number of positional arguments.  ``f(x, y=1)`` has 1."""
+    def num_pos_args(sigspec):
+        """ Return the number of positional arguments.  ``f(x, y=1)`` has 1"""
         return sum(1 for x in sigspec.parameters.values()
-                   if x.kind == x.POSITIONAL_OR_KEYWORD and
-                   x.default is x.empty)
+                   if x.kind == x.POSITIONAL_OR_KEYWORD
+                   and x.default is x.empty)
 
-    def get_exclude_keywords(func, num_pos_only, sigspec):
-        """Return the names of position-only arguments if func has **kwargs"""
+    def get_exclude_keywords(num_pos_only, sigspec):
+        """ Return the names of position-only arguments if func has **kwargs"""
         if num_pos_only == 0:
             return ()
         has_kwargs = any(x.kind == x.VAR_KEYWORD
@@ -646,14 +644,14 @@ if PY3:  # pragma: py2 no cover
             return e
 
 else:  # pragma: py3 no cover
-    def num_pos_args(func, sigspec):
-        """Return the number of positional arguments.  ``f(x, y=1)`` has 1."""
+    def num_pos_args(sigspec):
+        """ Return the number of positional arguments.  ``f(x, y=1)`` has 1"""
         if sigspec.defaults:
             return len(sigspec.args) - len(sigspec.defaults)
         return len(sigspec.args)
 
-    def get_exclude_keywords(func, num_pos_only, sigspec):
-        """Return the names of position-only arguments if func has **kwargs"""
+    def get_exclude_keywords(num_pos_only, sigspec):
+        """ Return the names of position-only arguments if func has **kwargs"""
         if num_pos_only == 0:
             return ()
         has_kwargs = sigspec.keywords is not None
@@ -669,7 +667,7 @@ else:  # pragma: py3 no cover
 
 
 def expand_sig(sig):
-    """Convert the signature spec in ``module_info`` to add to ``signatures``.
+    """ Convert the signature spec in ``module_info`` to add to ``signatures``
 
     The input signature spec is one of:
         - ``lambda_func``
@@ -684,7 +682,6 @@ def expand_sig(sig):
     included to support builtins such as ``partial(func, *args, **kwargs)``,
     which allows ``func=`` to be used as a keyword even though it's the name
     of a positional argument.
-
     """
     if isinstance(sig, tuple):
         if len(sig) == 3:
@@ -697,9 +694,9 @@ def expand_sig(sig):
     else:
         func = sig
         sigspec = signature_or_spec(func)
-        num_pos_only = num_pos_args(func, sigspec)
+        num_pos_only = num_pos_args(sigspec)
         keyword_only = ()
-    keyword_exclude = get_exclude_keywords(func, num_pos_only, sigspec)
+    keyword_exclude = get_exclude_keywords(num_pos_only, sigspec)
     return (num_pos_only, func, keyword_only + keyword_exclude, sigspec)
 
 
@@ -720,7 +717,7 @@ def create_signature_registry(module_info=module_info, signatures=signatures):
 
 
 def check_valid(sig, args, kwargs):
-    """Like ``is_valid_args`` for the given signature spec."""
+    """ Like ``is_valid_args`` for the given signature spec"""
     num_pos_only, func, keyword_exclude, sigspec = sig
     if len(args) < num_pos_only:
         return False
@@ -736,7 +733,7 @@ def check_valid(sig, args, kwargs):
 
 
 def _is_valid_args(func, args, kwargs):
-    """Like ``is_valid_args`` for builtins in our ``signatures`` registry."""
+    """ Like ``is_valid_args`` for builtins in our ``signatures`` registry"""
     if func not in signatures:
         return None
     sigs = signatures[func]
@@ -744,7 +741,7 @@ def _is_valid_args(func, args, kwargs):
 
 
 def check_partial(sig, args, kwargs):
-    """Like ``is_partial_args`` for the given signature spec."""
+    """ Like ``is_partial_args`` for the given signature spec"""
     num_pos_only, func, keyword_exclude, sigspec = sig
     if len(args) < num_pos_only:
         pad = (None,) * (num_pos_only - len(args))
@@ -757,7 +754,7 @@ def check_partial(sig, args, kwargs):
 
 
 def _is_partial_args(func, args, kwargs):
-    """Like ``is_partial_args`` for builtins in our ``signatures`` registry."""
+    """ Like ``is_partial_args`` for builtins in our ``signatures`` registry"""
     if func not in signatures:
         return None
     sigs = signatures[func]

--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -1,12 +1,12 @@
 import operator
 import sys
 PY3 = sys.version_info[0] > 2
-PY33 = sys.version_info[0] == 3 and sys.version_info[1] == 3
 PY34 = sys.version_info[0] == 3 and sys.version_info[1] == 4
 PYPY = hasattr(sys, 'pypy_version_info')
 
-__all__ = ('PY3', 'map', 'filter', 'range', 'zip', 'reduce', 'zip_longest',
-           'iteritems', 'iterkeys', 'itervalues', 'filterfalse')
+__all__ = ('map', 'filter', 'range', 'zip', 'reduce', 'zip_longest',
+           'iteritems', 'iterkeys', 'itervalues', 'filterfalse',
+           'PY3', 'PY34', 'PYPY')
 
 if PY3:
     map = map

--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -1,6 +1,7 @@
 import operator
 import sys
 PY3 = sys.version_info[0] > 2
+PY33 = sys.version_info[0] == 3 and sys.version_info[1] == 3
 PY34 = sys.version_info[0] == 3 and sys.version_info[1] == 4
 PYPY = hasattr(sys, 'pypy_version_info')
 

--- a/toolz/curried/__init__.py
+++ b/toolz/curried/__init__.py
@@ -23,8 +23,6 @@ Example:
 See Also:
     toolz.functoolz.curry
 """
-import inspect
-
 from . import exceptions
 from . import operator
 import toolz

--- a/toolz/curried/__init__.py
+++ b/toolz/curried/__init__.py
@@ -30,17 +30,13 @@ from . import operator
 import toolz
 
 
-def _nargs(f):
-    try:
-        return len(inspect.getargspec(f).args)
-    except TypeError:
-        return 0
-
-
-def _should_curry(f):
-    do_curry = frozenset((toolz.map, toolz.filter, toolz.sorted, toolz.reduce,
-                          toolz.excepts))
-    return (callable(f) and _nargs(f) > 1 or f in do_curry)
+def _should_curry(func):
+    if not callable(func) or isinstance(func, toolz.curry):
+        return False
+    nargs = toolz.functoolz.num_required_args(func)
+    if nargs is None or nargs > 1:
+        return True
+    return nargs == 1 and toolz.functoolz.has_keywords(func)
 
 
 def _curry_namespace(ns):
@@ -56,7 +52,6 @@ locals().update(toolz.merge(
 ))
 
 # Clean up the namespace.
-del _nargs
 del _should_curry
 del exceptions
 del toolz

--- a/toolz/curried/operator.py
+++ b/toolz/curried/operator.py
@@ -2,29 +2,22 @@ from __future__ import absolute_import
 
 import operator
 
-from toolz import curry
+from toolz.functoolz import curry, num_required_args, has_keywords
 
 
-# We use a blacklist instead of whitelist because:
-#   1. We have more things to include than exclude.
-#   2. This gives us access to things like matmul iff we are in Python >=3.5.
-no_curry = frozenset((
-    'abs',
-    'index',
-    'inv',
-    'invert',
-    'neg',
-    'not_',
-    'pos',
-    'truth',
-))
+def should_curry(f):
+    num = num_required_args(f)
+    return num is None or num > 1 or num == 1 and has_keywords(f) is not False
+
 
 locals().update(
-    dict((name, curry(f) if name not in no_curry else f)
+    dict((name, curry(f) if should_curry(f) else f)
          for name, f in vars(operator).items() if callable(f)),
 )
 
 # Clean up the namespace.
 del curry
-del no_curry
+del num_required_args
+del has_keywords
 del operator
+del should_curry

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -182,8 +182,7 @@ def itemfilter(predicate, d, factory=dict):
 
 
 def assoc(d, key, value, factory=dict):
-    """
-    Return a new dict with new key value pair
+    """ Return a new dict with new key value pair
 
     New dict has d[key] set to value. Does not modify the initial dictionary.
 
@@ -198,8 +197,7 @@ def assoc(d, key, value, factory=dict):
 
 
 def dissoc(d, *keys):
-    """
-    Return a new dict with the given key(s) removed.
+    """ Return a new dict with the given key(s) removed.
 
     New dict has d[key] deleted for each supplied key.
     Does not modify the initial dictionary.
@@ -219,8 +217,7 @@ def dissoc(d, *keys):
 
 
 def assoc_in(d, keys, value, factory=dict):
-    """
-    Return a new dict with new, potentially nested, key value pair
+    """ Return a new dict with new, potentially nested, key value pair
 
     >>> purchase = {'name': 'Alice',
     ...             'order': {'items': ['Apple', 'Orange'],
@@ -280,8 +277,7 @@ def update_in(d, keys, func, default=None, factory=dict):
 
 
 def get_in(keys, coll, default=None, no_default=False):
-    """
-    Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.
+    """ Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.
 
     If coll[i0][i1]...[iX] cannot be found, returns ``default``, unless
     ``no_default`` is specified, then it raises KeyError or IndexError.

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -213,8 +213,6 @@ class curry(object):
             sig = inspect.signature(self.func)
             args = self.args or ()
             keywords = self.keywords or {}
-            # print(self.func, args, keywords, is_partial_args(self.func,
-            #       args, keywords, sig))
             if is_partial_args(self.func, args, keywords, sig) is False:
                 raise TypeError('curry object has incorrect arguments')
 

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -216,17 +216,16 @@ class curry(object):
             if is_partial_args(self.func, args, keywords, sig) is False:
                 raise TypeError('curry object has incorrect arguments')
 
-            params = list(sig.parameters.items())
-            index = 0
-            for arg in args:
-                name, param = params[index]
+            params = list(sig.parameters.values())
+            skip = 0
+            for param in params[:len(args)]:
                 if param.kind == param.VAR_POSITIONAL:
                     break
-                index += 1
+                skip += 1
 
             kwonly = False
             newparams = []
-            for index, (name, param) in enumerate(params[index:]):
+            for param in params[skip:]:
                 kind = param.kind
                 default = param.default
                 if kind == param.VAR_KEYWORD:
@@ -234,14 +233,14 @@ class curry(object):
                 elif kind == param.VAR_POSITIONAL:
                     if kwonly:
                         continue
-                elif name in keywords:
-                    default = keywords[name]
+                elif param.name in keywords:
+                    default = keywords[param.name]
                     kind = param.KEYWORD_ONLY
                     kwonly = True
                 else:
                     if kwonly:
                         kind = param.KEYWORD_ONLY
-                    if param.default is param.empty:
+                    if default is param.empty:
                         default = no_default
                 newparams.append(param.replace(default=default, kind=kind))
 
@@ -753,7 +752,7 @@ _check_sigspec.__doc__ = """ \
 Private function to aid in introspection compatibly across Python versions.
 
 If a callable doesn't have a signature (Python 3) or an argspec (Python 2),
-our signature registry in toolz._signatures is used.
+the signature registry in toolz._signatures is used.
 """
 
 if PY3:  # pragma: py2 no cover

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -652,8 +652,8 @@ if PY3:  # pragma: py2 no cover
             return None, builtin_func(*builtin_args)
         elif isinstance(sigspec, TypeError):
             return None, False
-        elif not isinstance(sigspec, inspect.Signature):  # pragma: no cover
-            return None, False
+        elif not isinstance(sigspec, inspect.Signature):
+            return None, False  # pragma: no cover
         return sigspec, None
 
 else:  # pragma: py3 no cover

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 from textwrap import dedent
 import sys
 
-from .compatibility import PY3, PY34, PYPY
+from .compatibility import PY3, PY33, PY34, PYPY
 from .utils import no_default
 
 
@@ -203,18 +203,15 @@ class curry(object):
         self.__name__ = getattr(func, '__name__', '<curry>')
         self._sigspec = None
         self._has_unknown_args = None
-        # self.__wrapped__ = self.func
 
     @instanceproperty
     def func(self):
         return self._partial.func
 
-    __wrapped__ = func  # XXX: doesn't work in PY33
-
-    if PY3:  # pragma: py2 no cover
+    if PY3 and not PY33:  # pragma: no cover
         @instanceproperty
         def __signature__(self):
-            sig = inspect.signature(self._partial)  # XXX: doesn't work in PY33
+            sig = inspect.signature(self._partial)
 
             def make_optional(p):
                 if (

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -652,7 +652,7 @@ if PY3:  # pragma: py2 no cover
             return None, builtin_func(*builtin_args)
         elif isinstance(sigspec, TypeError):
             return None, False
-        elif not isinstance(sigspec, inspect.Signature):
+        elif not isinstance(sigspec, inspect.Signature):  # pragma: no cover
             return None, False
         return sigspec, None
 

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -597,7 +597,6 @@ def iterate(func, x):
     4
     >>> next(powers_of_two)
     8
-
     """
     while True:
         yield x
@@ -865,8 +864,7 @@ def diff(*seqs, **kwargs):
 
 
 def topk(k, seq, key=None):
-    """
-    Find the k largest elements of a sequence
+    """ Find the k largest elements of a sequence
 
     Operates lazily in ``n*log(k)`` time
 
@@ -898,7 +896,6 @@ def peek(seq):
     0
     >>> list(seq)
     [0, 1, 2, 3, 4]
-
     """
     iterator = iter(seq)
     item = next(iterator)
@@ -906,8 +903,7 @@ def peek(seq):
 
 
 def random_sample(prob, seq, random_state=None):
-    """
-    Return elements from a sequence with probability of prob
+    """ Return elements from a sequence with probability of prob
 
     Returns a lazy iterator of random items from seq.
 

--- a/toolz/tests/test_curried.py
+++ b/toolz/tests/test_curried.py
@@ -48,9 +48,14 @@ def test_curried_operator():
         if not isinstance(v, toolz.curry):
             try:
                 # Make sure it is unary
-                # We cannot use isunary because it might be defined in C.
                 v(1)
             except TypeError:
+                try:
+                    v('x')
+                except TypeError:
+                    pass
+                else:
+                    continue
                 raise AssertionError(
                     'toolz.curried.operator.%s is not curried!' % k,
                 )

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -5,7 +5,7 @@ from toolz.functoolz import (thread_first, thread_last, memoize, curry,
 from operator import add, mul, itemgetter
 from toolz.utils import raises
 from functools import partial
-from toolz.compatibility import PY3
+
 
 def iseven(x):
     return x % 2 == 0

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -277,6 +277,9 @@ def test_curry_attributes_readonly():
     assert raises(AttributeError, lambda: setattr(f, 'args', (2,)))
     assert raises(AttributeError, lambda: setattr(f, 'keywords', {'c': 3}))
     assert raises(AttributeError, lambda: setattr(f, 'func', f))
+    assert raises(AttributeError, lambda: delattr(f, 'args'))
+    assert raises(AttributeError, lambda: delattr(f, 'keywords'))
+    assert raises(AttributeError, lambda: delattr(f, 'func'))
 
 
 def test_curry_attributes_writable():

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -425,17 +425,6 @@ def test_memoize_on_classmethods():
     assert A.addstatic(3, 4) == 7
 
 
-def test_curry_wrapped():
-
-    def foo(a):
-        """
-        Docstring
-        """
-        pass
-    curried_foo = curry(foo)
-    assert curried_foo.__wrapped__ is foo
-
-
 def test_curry_call():
     @curry
     def add(x, y):

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -316,8 +316,15 @@ def test_introspect_builtin_modules():
     mods = [builtins, functools, itertools, operator]
 
     blacklist = set()
-    if hasattr(builtins, 'basestring'):
-        blacklist.add(builtins.basestring)
+
+    def add_blacklist(mod, attr):
+        if hasattr(mod, attr):
+            blacklist.add(getattr(mod, attr))
+
+    add_blacklist(builtins, 'basestring')
+    add_blacklist(builtins, 'NoneType')
+    add_blacklist(builtins, '__metaclass__')
+    add_blacklist(builtins, 'sequenceiterator')
 
     def is_missing(modname, name, func):
         if name.startswith('_') and not name.startswith('__'):

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -6,7 +6,7 @@ import toolz
 from toolz.functoolz import (curry, is_valid_args, is_partial_args, is_arity,
                              num_required_args, has_varargs, has_keywords)
 from toolz._signatures import builtins
-from toolz.compatibility import PY3
+from toolz.compatibility import PY3, PY33
 from toolz.utils import raises
 
 
@@ -314,7 +314,7 @@ def test_is_arity():
 
 
 def test_introspect_curry_valid_py3(check_valid=is_valid_args, incomplete=False):
-    if not PY3:
+    if not PY3 or PY33:
         return
     orig_check_valid = check_valid
     check_valid = lambda _func, *args, **kwargs: orig_check_valid(_func, args, kwargs)
@@ -344,7 +344,7 @@ def test_introspect_curry_partial_py3():
 
 
 def test_introspect_curry_py3():
-    if not PY3:
+    if not PY3 or PY33:
         return
     f = toolz.curry(make_func(''))
     assert num_required_args(f) == 0

--- a/toolz/tests/test_serialization.py
+++ b/toolz/tests/test_serialization.py
@@ -1,4 +1,5 @@
 from toolz import *
+import toolz
 import pickle
 
 
@@ -28,3 +29,14 @@ def test_complement():
     g = pickle.loads(pickle.dumps(f))
     assert f(True) == g(True)
     assert f(False) == g(False)
+
+
+def test_instanceproperty():
+    p = toolz.functoolz.InstanceProperty(bool)
+    assert p.__get__(None) is None
+    assert p.__get__(0) is False
+    assert p.__get__(1) is True
+    p2 = pickle.loads(pickle.dumps(p))
+    assert p2.__get__(None) is None
+    assert p2.__get__(0) is False
+    assert p2.__get__(1) is True

--- a/toolz/tests/test_signatures.py
+++ b/toolz/tests/test_signatures.py
@@ -1,12 +1,12 @@
 import functools
 import sys
-from toolz._signatures import (builtins, is_builtin_valid_args,
-                               is_builtin_partial_args)
+import toolz._signatures as _sigs
+from toolz._signatures import builtins, _is_valid_args, _is_partial_args
 from toolz.compatibility import PY3
 from toolz.utils import raises
 
 
-def test_is_valid(check_valid=is_builtin_valid_args, incomplete=False):
+def test_is_valid(check_valid=_is_valid_args, incomplete=False):
     orig_check_valid = check_valid
     check_valid = lambda func, *args, **kwargs: orig_check_valid(func, args, kwargs)
 
@@ -77,5 +77,13 @@ def test_is_valid(check_valid=is_builtin_valid_args, incomplete=False):
 
 
 def test_is_partial():
-    test_is_valid(check_valid=is_builtin_partial_args, incomplete=True)
+    test_is_valid(check_valid=_is_partial_args, incomplete=True)
+
+
+def test_for_coverage():  # :)
+    assert _sigs._is_arity(1, 1) is None
+    assert _sigs._is_arity(1, all)
+    assert _sigs._has_varargs(None) is None
+    assert _sigs._has_keywords(None) is None
+    assert _sigs._num_required_args(None) is None
 

--- a/toolz/tests/test_signatures.py
+++ b/toolz/tests/test_signatures.py
@@ -1,9 +1,7 @@
 import functools
-import sys
 import toolz._signatures as _sigs
 from toolz._signatures import builtins, _is_valid_args, _is_partial_args
 from toolz.compatibility import PY3
-from toolz.utils import raises
 
 
 def test_is_valid(check_valid=_is_valid_args, incomplete=False):


### PR DESCRIPTION
Add more functions for introspection in `functoolz` namespace.

All introspection methods return True, False, or None.  They shouldn't lie.

The current scope of introspection is to support other functions in `toolz`.  We may add more for compelling use cases.

For `curry`:
    - `is_valid_args`
    - `is_partial_args`
    - `has_varargs` (formerly `has_unknown_args`)

For `memoize`:
    - `num_required_args` (was previously private and removed)
    - `has_keywords` (formerly `has_kwargs`)
    - `is_arity` (replaces `isunary`)

A test was added to verify we can introspect every function from these modules:
    - `builtins`
    - `functools`
    - `itertools`
    - `operator`

This isn't quite finished.  I need to add docstrings.  I may also update how we build the `curried` namespace.