### PR TITLE
Use our introspection registry when `inspect.signature` fails due to inspecting properties

### DIFF
--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -1,6 +1,7 @@
 import operator
 import sys
 PY3 = sys.version_info[0] > 2
+PY33 = sys.version_info[0] == 3 and sys.version_info[1] == 3
 PY34 = sys.version_info[0] == 3 and sys.version_info[1] == 4
 PYPY = hasattr(sys, 'pypy_version_info')
 

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -579,10 +579,10 @@ def test_flip():
 def test_excepts():
     # These are descriptors, make sure this works correctly.
     assert excepts.__name__ == 'excepts'
-    assert excepts.__doc__.startswith(
+    assert (
         'A wrapper around a function to catch exceptions and\n'
         '    dispatch to a handler.\n'
-    )
+    ) in excepts.__doc__
 
     def idx(a):
         """idx docstring

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -1,11 +1,13 @@
 import functools
+import inspect
 import itertools
 import operator
 import toolz
 from toolz.functoolz import (curry, is_valid_args, is_partial_args, is_arity,
                              num_required_args, has_varargs, has_keywords)
 from toolz._signatures import builtins
-from toolz.compatibility import PY3
+import toolz._signatures as _sigs
+from toolz.compatibility import PY3, PY33
 from toolz.utils import raises
 
 
@@ -434,4 +436,63 @@ def test_introspect_builtin_modules():
             messages.append(msg)
         message = 'Missing introspection for the following callables:\n\n'
         raise AssertionError(message + '\n\n'.join(messages))
+
+
+def test_inspect_signature_property():
+    if not PY3:
+        return
+
+    # By adding AddX to our signature registry, we can inspect the class
+    # itself and objects of the class.  `inspect.signature` doesn't like
+    # it when `obj.__signature__` is a property.
+    class AddX(object):
+        def __init__(self, func):
+            self.func = func
+
+        def __call__(self, addx, *args, **kwargs):
+            return addx + self.func(*args, **kwargs)
+
+        @property
+        def __signature__(self):
+            sig = inspect.signature(self.func)
+            params = list(sig.parameters.values())
+            kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
+            newparam = inspect.Parameter('addx', kind)
+            params = [newparam] + params
+            return sig.replace(parameters=params)
+
+    addx = AddX(lambda x: x)
+    sig = inspect.signature(addx)
+    assert sig == inspect.Signature(parameters=[
+        inspect.Parameter('addx', inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        inspect.Parameter('x', inspect.Parameter.POSITIONAL_OR_KEYWORD)])
+
+    assert num_required_args(AddX) is False
+    _sigs.signatures[AddX] = (_sigs.expand_sig((0, lambda func: None)),)
+    assert num_required_args(AddX) == 1
+    del _sigs.signatures[AddX]
+
+
+def test_inspect_wrapped_property():
+    if not PY33:
+        return
+
+    class Wrapped(object):
+        def __init__(self, func):
+            self.func = func
+
+        def __call__(self, *args, **kwargs):
+            return self.func(*args, **kwargs)
+
+        @property
+        def __wrapped__(self):
+            return self.func
+
+    func = lambda x: x
+    wrapped = Wrapped(func)
+    assert inspect.signature(func) == inspect.signature(wrapped)
+
+    assert num_required_args(Wrapped) is False
+    _sigs.signatures[Wrapped] = (_sigs.expand_sig((0, lambda func: None)),)
+    assert num_required_args(Wrapped) == 1
 

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -415,7 +415,9 @@ def test_introspect_builtin_modules():
         except TypeError:
             pass
         try:
-            return (callable(func) and modname in func.__module__
+            return (callable(func)
+                    and func.__module__ is not None
+                    and modname in func.__module__
                     and is_partial_args(func, (), {}) is not True
                     and func not in blacklist)
         except AttributeError:

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -474,9 +474,6 @@ def test_inspect_signature_property():
 
 
 def test_inspect_wrapped_property():
-    if not PY33:
-        return
-
     class Wrapped(object):
         def __init__(self, func):
             self.func = func
@@ -490,9 +487,10 @@ def test_inspect_wrapped_property():
 
     func = lambda x: x
     wrapped = Wrapped(func)
-    assert inspect.signature(func) == inspect.signature(wrapped)
+    if PY3:
+        assert inspect.signature(func) == inspect.signature(wrapped)
 
-    assert num_required_args(Wrapped) is False
+    assert num_required_args(Wrapped) == (False if PY33 else None)
     _sigs.signatures[Wrapped] = (_sigs.expand_sig((0, lambda func: None)),)
     assert num_required_args(Wrapped) == 1
 


### PR DESCRIPTION
Unfortunately, `inspect.signature` fails to inspect classes that define
`__signature__` as a property.  Python 3.3 also fails when `__wrapped__`
is a property.  We add these specific edge cases to our inspection handling
and use our registry if possible.  This is needed to support `cytoolz`.

I bet we could fix this in future versions of Python by submitting a
bug/patch to https://bugs.python.com