### PR TITLE
Use `==` instead of `is` to check for no_default

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -56,7 +56,7 @@ def accumulate(binop, seq, initial=no_default):
         itertools.accumulate :  In standard itertools for Python 3.2+
     """
     seq = iter(seq)
-    result = next(seq) if initial is no_default else initial
+    result = next(seq) if initial == no_default else initial
     yield result
     for elem in seq:
         result = binop(result, elem)
@@ -397,7 +397,7 @@ def get(ind, seq, default=no_default):
         return seq[ind]
     except TypeError:  # `ind` may be a list
         if isinstance(ind, list):
-            if default is no_default:
+            if default == no_default:
                 if len(ind) > 1:
                     return operator.itemgetter(*ind)(seq)
                 elif ind:
@@ -406,12 +406,12 @@ def get(ind, seq, default=no_default):
                     return ()
             else:
                 return tuple(_get(i, seq, default) for i in ind)
-        elif default is not no_default:
+        elif default != no_default:
             return default
         else:
             raise
     except (KeyError, IndexError):  # we know `ind` is not a list
-        if default is no_default:
+        if default == no_default:
             raise
         else:
             return default
@@ -555,7 +555,8 @@ def reduceby(key, binop, seq, init=no_default):
     {True:  set([2, 4]),
      False: set([1, 3])}
     """
-    if init is not no_default and not callable(init):
+    is_no_default = init == no_default
+    if not is_no_default and not callable(init):
         _init = init
         init = lambda: _init
     if not callable(key):
@@ -564,7 +565,7 @@ def reduceby(key, binop, seq, init=no_default):
     for item in seq:
         k = key(item)
         if k not in d:
-            if init is no_default:
+            if is_no_default:
                 d[k] = item
                 continue
             else:
@@ -721,7 +722,7 @@ def pluck(ind, seqs, default=no_default):
         get
         map
     """
-    if default is no_default:
+    if default == no_default:
         get = getter(ind)
         return map(get, seqs)
     elif isinstance(ind, list):
@@ -805,6 +806,7 @@ def join(leftkey, leftseq, rightkey, rightseq,
     d = groupby(leftkey, leftseq)
     seen_keys = set()
 
+    left_default_is_no_default = (left_default == no_default)
     for item in rightseq:
         key = rightkey(item)
         seen_keys.add(key)
@@ -813,10 +815,10 @@ def join(leftkey, leftseq, rightkey, rightseq,
             for match in left_matches:
                 yield (match, item)
         except KeyError:
-            if left_default is not no_default:
+            if not left_default_is_no_default:
                 yield (left_default, item)
 
-    if right_default is not no_default:
+    if right_default != no_default:
         for key, matches in d.items():
             if key not in seen_keys:
                 for match in matches:
@@ -847,7 +849,7 @@ def diff(*seqs, **kwargs):
     if N < 2:
         raise TypeError('Too few sequences given (min 2 required)')
     default = kwargs.get('default', no_default)
-    if default is no_default:
+    if default == no_default:
         iters = zip(*seqs)
     else:
         iters = zip_longest(*seqs, fillvalue=default)

--- a/toolz/sandbox/parallel.py
+++ b/toolz/sandbox/parallel.py
@@ -49,7 +49,7 @@ def fold(binop, seq, default=no_default, map=map, chunksize=128, combine=None):
     chunks = partition_all(chunksize, seq)
 
     # Evaluate sequence in chunks via map
-    if default is no_default:
+    if default == no_default:
         results = map(lambda chunk: reduce(binop, chunk), chunks)
     else:
         results = map(lambda chunk: reduce(binop, chunk, default), chunks)

--- a/toolz/sandbox/tests/test_parallel.py
+++ b/toolz/sandbox/tests/test_parallel.py
@@ -1,6 +1,10 @@
 from toolz.sandbox.parallel import fold
 from toolz import reduce
 from operator import add
+from pickle import dumps, loads
+
+# is comparison will fail between this and no_default
+no_default2 = loads(dumps('__no__default__'))
 
 
 def test_fold():
@@ -16,3 +20,5 @@ def test_fold():
     assert fold(setadd, [1, 2, 3], set()) == set((1, 2, 3))
     assert (fold(setadd, [1, 2, 3], set(), chunksize=2, combine=set.union)
             == set((1, 2, 3)))
+
+    assert fold(add, range(10), default=no_default2) == fold(add, range(10))


### PR DESCRIPTION
Previously, `is` was used to check if keywords were equivalent to
`no_default`. This failed if the default string was serialized using
pickle, as they the reconstructed string isn't the same object. This PR
fixes that by replacing all `is` checks for `no_default` with `==`. Some
rearranging of the checks is done to avoid repeating comparisons. Tests
are also added to ensure this behavior remains consistent.

Fixes #309.