### PR TITLE
Implemented `constantly` in functoolz

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -60,6 +60,7 @@ Functoolz
 .. autosummary::
    complement
    compose
+   constantly
    curry
    do
    excepts

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -636,6 +636,8 @@ def constantly(v):
 
 
 return_none = constantly(None)
+return_none.__doc__ = """Returns None.
+    """
 
 
 class excepts(object):

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -621,10 +621,21 @@ def flip(func, a, b):
     return func(b, a)
 
 
-def return_none(exc):
-    """ Returns None.
+def constantly(v):
+    """Create function that always returns `v`, independent of its input.
+
+    >>> f = constantly(3)
+    >>> f(10)
+    3
+    >>> f(obj)
+    3
     """
-    return None
+    def inner(*args, **kwargs):
+        return v
+    return inner
+
+
+return_none = constantly(None)
 
 
 class excepts(object):

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -622,12 +622,12 @@ def flip(func, a, b):
 
 
 def constantly(v):
-    """Create function that always returns `v`, independent of its input.
+    """Create function that always returns ``v``, independent of its input
 
     >>> f = constantly(3)
     >>> f(10)
     3
-    >>> f(obj)
+    >>> f({'any': 'obj'}, 'and', any='amt')
     3
     """
     def inner(*args, **kwargs):

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -1,7 +1,8 @@
 import platform
 
-from toolz.functoolz import (thread_first, thread_last, memoize, curry,
-                             compose, pipe, complement, do, juxt, flip, excepts)
+from toolz.functoolz import (thread_first, thread_last, memoize, curry, compose,
+                             pipe, complement, do, juxt, flip, excepts,
+                             constantly)
 from operator import add, mul, itemgetter
 from toolz.utils import raises
 from functools import partial
@@ -574,6 +575,13 @@ def test_flip():
         return a, b
 
     assert flip(f, 'a', 'b') == ('b', 'a')
+
+
+def test_constantly():
+    f = constantly(42)
+
+    assert f() == 42
+    assert f(2) == 42
 
 
 def test_excepts():


### PR DESCRIPTION
Usage:

``` python
>>> f = constantly(42)
>>> f(any, parameters, here=80)
42
```

Examples in other languages:
- [clojure's `constantly`](https://clojuredocs.org/clojure.core/constantly)
- [haskell's `const`](http://hackage.haskell.org/package/base-4.9.0.0/docs/Prelude.html#v:const)
- [elm's `always`](http://package.elm-lang.org/packages/elm-lang/core/2.0.1/Basics#always)
