### PR TITLE
Add tests for pluck with default, non-None

### DIFF
--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -328,11 +328,10 @@ def test_pluck():
 
     data = [{'id': 1, 'name': 'cheese'}, {'id': 2, 'name': 'pies', 'price': 1}]
     assert list(pluck('id', data)) == [1, 2]
-    assert list(pluck('price', data, None)) == [None, 1]
+    assert list(pluck('price', data, 0)) == [0, 1]
     assert list(pluck(['id', 'name'], data)) == [(1, 'cheese'), (2, 'pies')]
     assert list(pluck(['name'], data)) == [('cheese',), ('pies',)]
-    assert list(pluck(['price', 'other'], data, None)) == [(None, None),
-                                                           (1, None)]
+    assert list(pluck(['price', 'other'], data, 0)) == [(0, 0), (1, 0)]
 
     assert raises(IndexError, lambda: list(pluck(1, [[0]])))
     assert raises(KeyError, lambda: list(pluck('name', [{'id': 1}])))


### PR DESCRIPTION
Needed for https://github.com/pytoolz/cytoolz/pull/82 (pluck with default would fail for non-None defaults).