### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Toolz
 
 A set of utility functions for iterators, functions, and dictionaries.
 
-See the PyToolz documentation at http://toolz.readthedocs.org
+See the PyToolz documentation at https://toolz.readthedocs.io
 
 LICENSE
 -------
@@ -48,7 +48,7 @@ These functions come from the legacy of functional languages for list
 processing. They interoperate well to accomplish common complex tasks.
 
 Read our `API
-Documentation <http://toolz.readthedocs.org/en/latest/api.html>`__ for
+Documentation <https://toolz.readthedocs.io/en/latest/api.html>`__ for
 more details.
 
 Example

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,5 +22,5 @@ test:
       - py.test -x --doctest-modules --pyargs toolz
 
 about:
-    home: http://toolz.readthedocs.org/
+    home: https://toolz.readthedocs.io/
     license: BSD

--- a/doc/source/streaming-analytics.rst
+++ b/doc/source/streaming-analytics.rst
@@ -307,9 +307,9 @@ composition, ...) users interested in data analytics might be better served by
 using projects specific to data analytics like Pandas_ or SQLAlchemy.
 
 
-.. _groupby: http://toolz.readthedocs.org/en/latest/api.html#toolz.itertoolz.groupby
-.. _join: http://toolz.readthedocs.org/en/latest/api.html#toolz.itertoolz.join
-.. _reduceby: http://toolz.readthedocs.org/en/latest/api.html#toolz.itertoolz.reduceby
-.. _valmap: http://toolz.readthedocs.org/en/latest/api.html#toolz.itertoolz.valmap
+.. _groupby: https://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.groupby
+.. _join: https://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.join
+.. _reduceby: https://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.reduceby
+.. _valmap: https://toolz.readthedocs.io/en/latest/api.html#toolz.dicttoolz.valmap
 .. _Pandas: http://pandas.pydata.org/pandas-docs/stable/groupby.html
-.. _curried: http://toolz.readthedocs.org/en/latest/curry.html
+.. _curried: https://toolz.readthedocs.io/en/latest/curry.html

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -169,7 +169,7 @@ class curry(object):
 
     See Also:
         toolz.curried - namespace of curried functions
-                        http://toolz.readthedocs.org/en/latest/curry.html
+                        https://toolz.readthedocs.io/en/latest/curry.html
     """
     def __init__(self, *args, **kwargs):
         if not args:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
