### PR TITLE
ENH: use update_wrapper in memoize

### DIFF
--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -158,7 +158,11 @@ def test_memoize_wrapped():
         Docstring
         """
         pass
+
     memoized_foo = memoize(foo)
+    assert memoized_foo.__name__ == foo.__name__
+    assert memoized_foo.__doc__ == foo.__doc__
+    assert memoized_foo.__module__ == foo.__module__ == __name__
     assert memoized_foo.__wrapped__ is foo
 
 


### PR DESCRIPTION
This backports the 3.{4,5,6} impl of update_wrapper so that we ignore
any attributes that are missing. This allows us to memoize things that
don't have a __name__ or other function attributes.