### PR TITLE
Fix SyntaxError and TypeError in Streaming Analytics Examples

### DIFF
--- a/doc/source/streaming-analytics.rst
+++ b/doc/source/streaming-analytics.rst
@@ -34,7 +34,7 @@ These functions correspond to the SQL commands ``SELECT`` and ``WHERE``.
 .. code::
 
    >>> from toolz.curried import pipe, map, filter, get
-   >>> pipe(accounts, filter(lambda (id, name, balance, gender): balance > 150),
+   >>> pipe(accounts, filter(lambda acc: acc[2] > 150),
    ...                map(get([1, 2])),
    ...                list)
 
@@ -150,9 +150,9 @@ that adds up the balances for each group:
 
 .. code::
 
-   >>> binop = lambda total, (id, name, bal, gend): total + bal
+   >>> binop = lambda total, account: total + account[2]
 
-   >>> reduceby(get(3), binop, accounts)
+   >>> reduceby(get(3), binop, accounts, 0)
    {'F': 400, 'M': 400}
 
 


### PR DESCRIPTION
Write: `lambda ... (id, name, bal, gend) ...`  as in example will give `SyntaxError: invalid syntax.` Instead use: `lambda account: account[2] ...`
`binop` function without `init=0` will give `TypeError: can only concatenate tuple (not "int") to tuple.`
I tested in Python3.4 and 3.5.