### PR TITLE
Package the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
+include LICENSE.txt
+
 include toolz/tests/*.py


### PR DESCRIPTION
Includes the license file in the `sdist` to aid in complying with the terms of BSD 3-Clause license.