### PR TITLE
Add generator

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -9,12 +9,27 @@ from toolz.compatibility import (map, filterfalse, zip, zip_longest, iteritems,
 from toolz.utils import no_default
 
 
-__all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
-           'unique', 'isiterable', 'isdistinct', 'take', 'drop', 'take_nth',
-           'first', 'second', 'nth', 'last', 'get', 'concat', 'concatv',
-           'mapcat', 'cons', 'interpose', 'frequencies', 'reduceby', 'iterate',
-           'sliding_window', 'partition', 'partition_all', 'count', 'pluck',
-           'join', 'tail', 'diff', 'topk', 'peek', 'random_sample')
+__all__ = ('remove', 'accumulate', 'generator', 'groupby', 'merge_sorted',
+           'interleave', 'unique', 'isiterable', 'isdistinct', 'take',
+           'drop', 'take_nth', 'first', 'second', 'nth', 'last', 'get',
+           'concat', 'concatv', 'mapcat', 'cons', 'interpose',
+           'frequencies', 'reduceby', 'iterate', 'sliding_window',
+           'partition', 'partition_all', 'count', 'pluck', 'join', 'tail',
+           'diff', 'topk', 'peek', 'random_sample')
+
+
+def generator(it):
+    """ Creates a generator type from the iterable.
+
+    >>> generator(range(5))  # doctest: +ELLIPSIS
+    <generator object generator at 0x...>
+
+    >>> list(generator(range(5)))
+    [0, 1, 2, 3, 4]
+    """
+
+    for each in it:
+        yield each
 
 
 def remove(predicate, seq):

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -1,10 +1,11 @@
 import itertools
+import types
 from itertools import starmap
 from toolz.utils import raises
 from functools import partial
 from random import Random
 from pickle import dumps, loads
-from toolz.itertoolz import (remove, groupby, merge_sorted,
+from toolz.itertoolz import (generator, remove, groupby, merge_sorted,
                              concat, concatv, interleave, unique,
                              isiterable, getter,
                              mapcat, isdistinct, first, second,
@@ -40,6 +41,14 @@ def inc(x):
 
 def double(x):
     return 2 * x
+
+
+def test_generator():
+    assert list(generator(range(5))) == [0, 1, 2, 3, 4]
+
+    assert isinstance(generator(range(5)), types.GeneratorType)
+    assert issubclass(type(generator(range(5))), types.GeneratorType)
+    assert type(generator(range(5))) is types.GeneratorType
 
 
 def test_remove():


### PR DESCRIPTION
Adds a function that returns a generator type from any iterable.

Note: This ends up being slightly faster in terms of construction time than returning a generator expression.