### PR TITLE
Run doctest on curried functions in `toolz`.  Fixes #348.

### DIFF
--- a/toolz/tests/test_curried_doctests.py
+++ b/toolz/tests/test_curried_doctests.py
@@ -1,0 +1,11 @@
+import doctest
+import toolz
+
+
+def test_doctests():
+    toolz.__test__ = {}
+    for name, func in vars(toolz).items():
+        if isinstance(func, toolz.curry):
+            toolz.__test__[name] = func.func
+    assert doctest.testmod(toolz).failed == 0
+    del toolz.__test__


### PR DESCRIPTION
Curried objects in other projects won't automatically get run.