### PR TITLE
Adds `transition` for source to sink mappings.

### DIFF
--- a/toolz/curried/__init__.py
+++ b/toolz/curried/__init__.py
@@ -52,7 +52,7 @@ from toolz import (
     thread_first,
     thread_last,
 )
-from .exceptions import merge, merge_with
+from .exceptions import merge, merge_with, transition
 
 accumulate = toolz.curry(toolz.accumulate)
 assoc = toolz.curry(toolz.assoc)

--- a/toolz/curried/exceptions.py
+++ b/toolz/curried/exceptions.py
@@ -14,5 +14,11 @@ def merge(d, *dicts, **kwargs):
     return toolz.merge(d, *dicts, **kwargs)
 
 
+@toolz.curry
+def transition(d, *dicts, **kwargs):
+    return toolz.transition(d, *dicts, **kwargs)
+
+
 merge_with.__doc__ = toolz.merge_with.__doc__
 merge.__doc__ = toolz.merge.__doc__
+transition.__doc__ = toolz.transition.__doc__

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -3,7 +3,8 @@ import operator
 from toolz.compatibility import (map, zip, iteritems, iterkeys, itervalues,
                                  reduce)
 
-__all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
+__all__ = ('merge', 'merge_with', 'transition',
+           'valmap', 'keymap', 'itemmap',
            'valfilter', 'keyfilter', 'itemfilter',
            'assoc', 'dissoc', 'assoc_in', 'update_in', 'get_in')
 
@@ -67,6 +68,54 @@ def merge_with(func, *dicts, **kwargs):
             else:
                 result[k].append(v)
     return valmap(func, result, factory)
+
+
+def transition(*dicts, **kwargs):
+    """ Return a transition map from an ordered collection of ditionaries.
+
+    Transition map is a new dict, constructed by following mappings from
+    source dict to sink dict. Does not modify original dictionaries.
+
+    >>> transition({1: 6, 2: 6, 3: 7, 4: 8, 5: None}, {7: 9, 6: 10})
+    {1: 10, 2: 10, 3: 9}
+
+    >>> transition({1: 1, 2: 2, 3: 3}, {}) # Gaps break the transition
+    {}
+
+    >>> transition({1: 1, 2: 2, 3: 3}, {}, {1: 4, 2: 5, 3: 6})
+    {}
+
+    >>> transition({1: None, 2: None, 3: None, 4: None}, {None: 5})
+    {1: 5, 2: 5, 3: 5, 4: 5}
+
+    >>> transition({1: 4, 2: 5, 3: 5}, {5: None})
+    {2: None, 3: None}
+    """
+    if len(dicts) == 1 and not isinstance(dicts[0], dict):
+        return dicts[0]
+    factory = _get_factory(transition, kwargs)
+
+    rv = factory()
+    curr = dicts[-1]
+    for prev in dicts[-2::-1]:
+        if not curr:
+            return factory()
+        rprev = {}
+        for k, v in iteritems(prev):
+            try:
+                rprev[v].add(k)
+            except KeyError:
+                rprev[v] = set((k,))
+
+        pks = set(iterkeys(prev))
+        cks = set(iterkeys(curr))
+        curr.update(dict((v, curr[k]) for (k, vs) in iteritems(rprev)
+                    for v in vs if k in cks))
+        for k in cks:
+            if k not in pks:
+                del curr[k]
+    rv.update(curr)
+    return rv
 
 
 def valmap(func, d, factory=dict):

--- a/toolz/tests/test_curried.py
+++ b/toolz/tests/test_curried.py
@@ -1,7 +1,7 @@
 import toolz
 import toolz.curried
 from toolz.curried import (take, first, second, sorted, merge_with, reduce,
-                           merge, operator as cop)
+                           merge, operator as cop, transition)
 from toolz.compatibility import import_module
 from collections import defaultdict
 from operator import add
@@ -23,6 +23,12 @@ def test_merge():
 
 def test_merge_with():
     assert merge_with(sum)({1: 1}, {1: 2}) == {1: 3}
+
+
+def test_transition():
+    assert transition(factory=lambda: defaultdict(int))({1: 1}) == {1: 1}
+    assert transition({1: 1}) == {1: 1}
+    assert transition({1: 1}, factory=lambda: defaultdict(int)) == {1: 1}
 
 
 def test_merge_with_list():
@@ -87,6 +93,7 @@ def test_curried_namespace():
     from_toolz = curry_namespace(vars(toolz))
     from_exceptions = curry_namespace(vars(exceptions))
     namespace.update(toolz.merge(from_toolz, from_exceptions))
+    namespace.update(toolz.transition(from_toolz, from_exceptions))
 
     namespace = toolz.valfilter(callable, namespace)
     curried_namespace = toolz.valfilter(callable, toolz.curried.__dict__)

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -1,7 +1,7 @@
 from collections import defaultdict as _defaultdict
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
                              assoc, dissoc, keyfilter, valfilter, itemmap,
-                             itemfilter, assoc_in)
+                             itemfilter, assoc_in, transition)
 from toolz.utils import raises
 from toolz.compatibility import PY3
 
@@ -50,6 +50,30 @@ class TestDict(object):
         assert merge_with(sum, *dicts, **kw) == D({1: 11, 2: 22})
         assert merge_with(sum, dicts, **kw) == D({1: 11, 2: 22})
         assert merge_with(sum, iter(dicts), **kw) == D({1: 11, 2: 22})
+
+    def test_transition(self):
+        D, kw = self.D, self.kw
+
+        dicts = D({}),
+        assert transition(*dicts, **kw) == D({})
+
+        dicts = D({1: 2, 2: 3, 3: 5}),
+        assert transition(*dicts, **kw) == dicts[0]
+
+        dicts = D({1: 6, 2: 6, 3: 7, 4: 8, 5: None}), D({7: 9, 6: 10})
+        assert transition(*dicts, **kw) == D({1: 10, 2: 10, 3: 9})
+
+        dicts = D({1: 1, 2: 2, 3: 3}), D({}), D({1: 4, 2: 5, 3: 6})
+        assert transition(*dicts, **kw) == D({})
+
+        dicts = D({1: 1, 2: 2, 3: 3}), D({})
+        assert transition(*dicts, **kw) == D({})
+
+        dicts = D({1: None, 2: None, 3: None, 4: None}), D({None: 5})
+        assert transition(*dicts, **kw) == D({1: 5, 2: 5, 3: 5, 4: 5})
+
+        dicts = D({1: 4, 2: 5, 3: 5}), D({5: None})
+        assert transition(*dicts, **kw) == D({2: None, 3: None})
 
     def test_valmap(self):
         D, kw = self.D, self.kw


### PR DESCRIPTION
`transition` returns a direct mapping from source to sink, given an ordered collection of `dict`s as input, which may contain several interim levels of transitions.