### PR TITLE
A slightly faster interpose.

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -520,8 +520,9 @@ def interpose(el, seq):
     >>> list(interpose("a", [1, 2, 3]))
     [1, 'a', 2, 'a', 3]
     """
-    combined = zip(itertools.repeat(el), seq)
-    return drop(1, concat(combined))
+    inposed = concat(zip(itertools.repeat(el), seq))
+    next(inposed)
+    return inposed
 
 
 def frequencies(seq):


### PR DESCRIPTION
Special case the removal of the first element.  Consumes the first element with a call to next() instead of using islice.

The downside is the function could be considered "less beautiful". Though, new implementation does make a certain logical sense.  We construct the interposed sequence in one line, then throw away the first element and return the rest of it.

Timings:
```python
# With Python 3.5.3 (conda-forge)
%timeit tuple(interpose('\n', range(1)))
1000000 loops, best of 3: 1.54 µs per loop
%timeit tuple(fast_interpose('\n', range(1)))
1000000 loops, best of 3: 1.33 µs per loop

%timeit tuple(interpose('\n', range(5)))
1000000 loops, best of 3: 1.88 µs per loop
%timeit tuple(fast_interpose('\n', range(5)))
1000000 loops, best of 3: 1.66 µs per loop

%timeit tuple(interpose('\n', range(1000000)))
10 loops, best of 3: 100 ms per loop
%timeit tuple(fast_interpose('\n', range(1000000)))
10 loops, best of 3: 94 ms per loop
```