### PR TITLE
add pick, destruct, evolve

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -90,6 +90,9 @@ Dicttoolz
    update_in
    valfilter
    valmap
+   pick
+   destruct
+   evolve
 
 Sandbox
 -------

--- a/toolz/curried/__init__.py
+++ b/toolz/curried/__init__.py
@@ -95,6 +95,9 @@ unique = toolz.curry(toolz.unique)
 update_in = toolz.curry(toolz.update_in)
 valfilter = toolz.curry(toolz.valfilter)
 valmap = toolz.curry(toolz.valmap)
+pick = toolz.curry(toolz.pick)
+destruct = toolz.curry(toolz.destruct)
+evolve = toolz.curry(toolz.evolve)
 
 del exceptions
 del toolz

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -4,8 +4,8 @@ from toolz.compatibility import (map, zip, iteritems, iterkeys, itervalues,
                                  reduce)
 
 __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
-           'valfilter', 'keyfilter', 'itemfilter',
-           'assoc', 'dissoc', 'assoc_in', 'update_in', 'get_in')
+           'valfilter', 'keyfilter', 'itemfilter', 'assoc', 'dissoc',
+           'assoc_in', 'update_in', 'get_in', 'pick', 'destruct', 'evolve')
 
 
 def _get_factory(f, kwargs):
@@ -313,3 +313,33 @@ def get_in(keys, coll, default=None, no_default=False):
         if no_default:
             raise
         return default
+
+def pick(keys, d):
+    """ Filter a dictionary to certain keys
+
+    >>> dic = pick(['foo', 'baz'], {'foo': 1, 'bar': 2, 'baz': 3})
+    {'foo': 1, 'baz': 3}
+    """
+    return {key: d[key] for key in keys}
+
+def destruct(keys, d):
+    """ Destructure variables from a dictionary
+
+    >>> foo, baz = destruct(['foo', 'baz'], {'foo': 1, 'bar': 2, 'baz': 3})
+    >>> foo
+    1
+    """
+    return (d[key] for key in keys)
+
+def evolve(transformations, d):
+    """ Change part of a dictionary
+
+    >>> evolve({'age': lambda x: 2*x}, {'name': 'me', 'age': 10})
+    {'name': 'me', 'age': 20}
+    """
+    result = {}
+    for key in d:
+        tform = transformations.get(key, None)
+        result[key] = tform(d[key]) if callable(tform) else \
+              evolve(tform, d[key]) if isinstance(tform, dict) else d[key]
+    return result

--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -1,7 +1,7 @@
 from collections import defaultdict as _defaultdict
 from toolz.dicttoolz import (merge, merge_with, valmap, keymap, update_in,
                              assoc, dissoc, keyfilter, valfilter, itemmap,
-                             itemfilter, assoc_in)
+                             itemfilter, assoc_in, pick, destruct, evolve)
 from toolz.utils import raises
 from toolz.compatibility import PY3
 
@@ -138,6 +138,32 @@ class TestDict(object):
         d = D({'x': 1})
         oldd = d
         update_in(d, ['x'], inc, **kw)
+        assert d is oldd
+
+    def test_pick(self):
+        D, kw = self.D, self.kw
+        d = D({'foo': 1, 'bar': 2, 'baz': 3})
+        oldd = d
+        assert pick(['foo', 'baz'], d) == {'foo': 1, 'baz': 3}
+        # Verify immutability:
+        assert d is oldd
+
+    def test_destruct(self):
+        D, kw = self.D, self.kw
+        d = D({'foo': 1, 'bar': 2, 'baz': 3})
+        oldd = d
+        foo, baz = destruct(['foo', 'baz'], d)
+        assert foo == 1
+        assert baz == 3
+        # Verify immutability:
+        assert d is oldd
+
+    def test_evolve(self):
+        D, kw = self.D, self.kw
+        d = D({'name': 'me', 'age': 10})
+        oldd = d
+        assert evolve({'age': lambda x: 2*x}, d) == { 'name': 'me', 'age': 20 }
+        # Verify immutability:
         assert d is oldd
 
     def test_factory(self):


### PR DESCRIPTION
#Hi, thank you for making `toolz`.

I'd written a few `dict` functions for personal use, so I figured I'd try and make a PR in case others would find them of use as well. `evolve` and `pick` were inspired by similar functions in JavaScript's Ramda library.
I'm new to this repo, so please advise me where I can improve.

I tried running the tests, but was met with an error:
> ImportError: cannot import name pick

I was under the impression I'd exported the functions, so I'm not sure what went wrong there. Might that ring any bells?
