### PR TITLE
FIX: compatibility with python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,15 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7-dev"
     - "pypy"
 
 env:
     - PEP8_IGNORE="E731,W503,E402"
+
+matrix:
+  allow_failures:
+    - python: "3.7-dev"
 
 # command to install dependencies
 install:

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -498,7 +498,7 @@ class Compose(object):
     def __name__(self):
         try:
             return '_of_'.join(
-                f.__name__ for f in reversed((self.first,) + self.funcs),
+                f.__name__ for f in reversed((self.first,) + self.funcs)
             )
         except AttributeError:
             return type(self).__name__

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -402,6 +402,7 @@ def test_introspect_builtin_modules():
             blacklist.add(getattr(mod, attr))
 
     add_blacklist(builtins, 'basestring')
+    add_blacklist(builtins, 'breakpoint')
     add_blacklist(builtins, 'NoneType')
     add_blacklist(builtins, '__metaclass__')
     add_blacklist(builtins, 'sequenceiterator')
@@ -497,4 +498,3 @@ def test_inspect_wrapped_property():
     assert num_required_args(Wrapped) == (False if PY33 else None)
     _sigs.signatures[Wrapped] = (_sigs.expand_sig((0, lambda func: None)),)
     assert num_required_args(Wrapped) == 1
-


### PR DESCRIPTION
This expression is broken by:

bpo-32012: Disallow trailing comma after genexpr without
parenthesis.

python/cpython#4382
python/cpython@9165f77d5f93a2c12aa0e90853e3ae7212800d3c