### PR TITLE
update non-working code example to use curried analogs

### DIFF
--- a/doc/source/streaming-analytics.rst
+++ b/doc/source/streaming-analytics.rst
@@ -97,8 +97,9 @@ Then we chain them together into a single computation
 
 .. code::
 
-   >>> pipe(accounts, groupby(get(3)),
-   ...                valmap(compose(sum, pluck(2))))
+   >>> import toolz.curried as curried
+   >>> pipe(accounts, curried.groupby(get(3)),
+   ...                curried.valmap(compose(sum, pluck(2))))
    {'F': 400, 'M': 400}
 
 


### PR DESCRIPTION
Fix a broken example (or at the very least, make it clearer that curried analogs must be used) from the streaming analytics docs.