### PR TITLE
Avoid using .index() in partition_all

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -728,7 +728,7 @@ def partition_all(n, seq):
             # https://github.com/pytoolz/toolz/issues/387
             # We can employ modified binary search here to speed things up from O(n) to O(log n)
             # Binary search from CPython's bisect module, modified for identity testing.
-            lo, hi = 0, len(prev)
+            lo, hi = 0, n
             while lo < hi:
                 mid = (lo + hi) // 2
                 if prev[mid] is no_pad:

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -720,12 +720,22 @@ def partition_all(n, seq):
         yield prev
         prev = item
     if prev[-1] is no_pad:
-        # Get first index of no_pad without using .index()
-        # https://github.com/pytoolz/toolz/issues/387
-        for ind, item in enumerate(reversed(prev)):
-            if item is not no_pad:
-                yield prev[:len(prev)-ind]
-                break
+        try:
+            # If seq defines __len__, then we can quickly calculate where no_pad starts
+            yield prev[:len(seq) % n]
+        except TypeError:
+            # Get first index of no_pad without using .index()
+            # https://github.com/pytoolz/toolz/issues/387
+            # We can employ modified binary search here to speed things up from O(n) to O(log n)
+            # Binary search from CPython's bisect module, modified for identity testing.
+            lo, hi = 0, len(prev)
+            while lo < hi:
+                mid = (lo + hi) // 2
+                if prev[mid] is no_pad:
+                    hi = mid
+                else:
+                    lo = mid + 1
+            yield prev[:lo]
     else:
         yield prev
 

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -720,7 +720,12 @@ def partition_all(n, seq):
         yield prev
         prev = item
     if prev[-1] is no_pad:
-        yield prev[:prev.index(no_pad)]
+        # Get first index of no_pad without using .index()
+        # https://github.com/pytoolz/toolz/issues/387
+        for ind, item in enumerate(reversed(prev)):
+            if item is not no_pad:
+                yield prev[:len(prev)-ind]
+                break
     else:
         yield prev
 

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -721,13 +721,14 @@ def partition_all(n, seq):
         prev = item
     if prev[-1] is no_pad:
         try:
-            # If seq defines __len__, then we can quickly calculate where no_pad starts
+            # If seq defines __len__, then
+            # we can quickly calculate where no_pad starts
             yield prev[:len(seq) % n]
         except TypeError:
             # Get first index of no_pad without using .index()
             # https://github.com/pytoolz/toolz/issues/387
-            # We can employ modified binary search here to speed things up from O(n) to O(log n)
-            # Binary search from CPython's bisect module, modified for identity testing.
+            # Binary search from CPython's bisect module,
+            # modified for identity testing.
             lo, hi = 0, n
             while lo < hi:
                 mid = (lo + hi) // 2

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -325,7 +325,9 @@ def test_partition_all():
                 return True
             raise ValueError()
     obj = NoCompare()
-    assert list(partition_all(2, [obj]*3)) == [(obj, obj), (obj,)]
+    result = [(obj, obj, obj, obj), (obj, obj, obj)]
+    assert list(partition_all(4, [obj]*7)) == result
+    assert list(partition_all(4, iter([obj]*7))) == result
 
 
 def test_count():

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -318,6 +318,16 @@ def test_partition_all():
     assert list(partition_all(3, range(5))) == [(0, 1, 2), (3, 4)]
     assert list(partition_all(2, [])) == []
 
+    # Regression test: https://github.com/pytoolz/toolz/issues/387
+    class NoCompare(object):
+        def __eq__(self, other):
+            if self.__class__ == other.__class__:
+                return True
+            raise ValueError()
+    obj = NoCompare()
+    assert list(partition_all(2, [obj]*3)) == [(obj, obj), (obj,)]
+
+
 
 def test_count():
     assert count((1, 2, 3)) == 3

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -328,7 +328,6 @@ def test_partition_all():
     assert list(partition_all(2, [obj]*3)) == [(obj, obj), (obj,)]
 
 
-
 def test_count():
     assert count((1, 2, 3)) == 3
     assert count([]) == 0


### PR DESCRIPTION
This PR fixes https://github.com/pytoolz/toolz/issues/387.

There is a slight performance hit, however for large sequences it is relatively small:
```
In [31]: seq = list(range(10000000))
In [32]: %timeit list(partition_all_old(3, seq))
411 ms ± 6.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [33]: %timeit list(partition_all(3, seq))
409 ms ± 1.62 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
The overhead is a little more noticeable for small sequences:
```
In [40]: seq = list(range(11))
In [41]: %timeit list(partition_all_old(2, seq))
1.87 µs ± 5.79 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [42]: %timeit list(partition_all(2, seq))
2.17 µs ± 21.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```