### PR TITLE
Avoid islice overhead in itertoolz.second

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -374,7 +374,9 @@ def second(seq):
     >>> second('ABC')
     'B'
     """
-    return next(itertools.islice(seq, 1, None))
+    seq = iter(seq)
+    next(seq)
+    return next(seq)
 
 
 def nth(n, seq):

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -375,8 +375,11 @@ def second(seq):
     'B'
     """
     seq = iter(seq)
-    next(seq)
-    return next(seq)
+    try:
+        next(seq)
+        return next(seq)
+    except StopIteration:
+        raise
 
 
 def nth(n, seq):

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -375,11 +375,8 @@ def second(seq):
     'B'
     """
     seq = iter(seq)
-    try:
-        next(seq)
-        return next(seq)
-    except StopIteration:
-        raise
+    next(seq)
+    return next(seq)
 
 
 def nth(n, seq):

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -17,6 +17,8 @@ from toolz.itertoolz import (remove, groupby, merge_sorted,
 from toolz.compatibility import range, filter
 from operator import add, mul
 
+import pytest
+
 
 # is comparison will fail between this and no_default
 no_default2 = loads(dumps('__no__default__'))
@@ -143,6 +145,12 @@ def test_second():
     assert second('ABCDE') == 'B'
     assert second((3, 2, 1)) == 2
     assert isinstance(second({0: 'zero', 1: 'one'}), int)
+    assert second(x for x in range(2)) == 1
+
+    # Python 3.7, StopIteration should be raised if iterable too short
+    with pytest.raises(StopIteration):
+        second([])
+        second([0])
 
 
 def test_last():

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -17,8 +17,6 @@ from toolz.itertoolz import (remove, groupby, merge_sorted,
 from toolz.compatibility import range, filter
 from operator import add, mul
 
-import pytest
-
 
 # is comparison will fail between this and no_default
 no_default2 = loads(dumps('__no__default__'))
@@ -145,12 +143,6 @@ def test_second():
     assert second('ABCDE') == 'B'
     assert second((3, 2, 1)) == 2
     assert isinstance(second({0: 'zero', 1: 'one'}), int)
-    assert second(x for x in range(2)) == 1
-
-    # Python 3.7, StopIteration should be raised if iterable too short
-    with pytest.raises(StopIteration):
-        second([])
-        second([0])
 
 
 def test_last():


### PR DESCRIPTION
Using itertools.islice seems to be slower than simply calling next twice. In each case, calling next twice is faster.

```python
m0 = range(5)
m1 = range(100)
m2 = range(10000)

In [17]: %timeit second(m0)
298 ns ± 5.18 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [18]: %timeit second(m1)
296 ns ± 4.49 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [19]: %timeit second(m2)
290 ns ± 3.98 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
===============================================
In [21]: %timeit my_second(m0)
263 ns ± 6.78 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [22]: %timeit my_second(m1)
257 ns ± 2.12 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [23]: %timeit my_second(m3)
263 ns ± 6.2 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```