### PR TITLE
Fix accumulate for Python 3.7

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -56,7 +56,13 @@ def accumulate(binop, seq, initial=no_default):
         itertools.accumulate :  In standard itertools for Python 3.2+
     """
     seq = iter(seq)
-    result = next(seq) if initial == no_default else initial
+    if initial == no_default:
+        try:
+            result = next(seq)
+        except StopIteration:
+            return
+    else:
+        result = initial
     yield result
     for elem in seq:
         result = binop(result, elem)

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -289,6 +289,7 @@ def test_accumulate():
 
     start = object()
     assert list(accumulate(binop, [], start)) == [start]
+    assert list(accumulate(binop, [])) == []
     assert list(accumulate(add, [1, 2, 3], no_default2)) == [1, 3, 6]
 
 


### PR DESCRIPTION
StopIteration is converted to RuntimeError if it escapes the generator frame.
Code updated to reflect recommendations made in PEP479.

This resolves #409 