### PR TITLE
More efficient assoc

### DIFF
--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -192,8 +192,9 @@ def assoc(d, key, value, factory=dict):
     {'x': 1, 'y': 3}
     """
     d2 = factory()
+    d2.update(d)
     d2[key] = value
-    return merge(d, d2, factory=factory)
+    return d2
 
 
 def dissoc(d, *keys):


### PR DESCRIPTION
Previously, assoc would call factory(), add a single key-value pair and then call merge.  Merge would then call factory() again and update the mapping with both the original mapping and the single element mapping.

This version avoids calling merge for updating a single value in the mapping (with only a single call to factory()).

```python
# len(a) == 10
In [6]: %timeit assoc(a, 'key', '42')
1.71 µs ± 92.2 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [7]: %timeit assoc1(a, 'key', '42')
768 ns ± 12.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

# len(b) == 1000
In [8]: %timeit assoc(b, 'key', '42')
25.6 µs ± 932 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [9]: %timeit assoc1(b, 'key', '42')
24.4 µs ± 862 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

# len(c) == 10000
In [10]: %timeit assoc(c, 'key', '42')
269 µs ± 7.74 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
In [11]: %timeit assoc1(c, 'key', '42')
265 µs ± 5.65 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```