### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,15 @@ python:
     - "3.7-dev"
     - "pypy"
 
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+    include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 env:
     - PEP8_IGNORE="E731,W503,E402"
-
-matrix:
-  allow_failures:
-    - python: "3.7-dev"
 
 # command to install dependencies
 install:

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(name='toolz',
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: Implementation :: CPython",
           "Programming Language :: Python :: Implementation :: PyPy"])


### PR DESCRIPTION
Remove `3.7-dev` (an old alpha version) and replace it with 3.7.0.

It needs a small workaround on Travis CI, see https://github.com/travis-ci/travis-ci/issues/9815 for details.