### PR TITLE
Fix DeprecationWarning in Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 dist/
 *.egg-info/
+bench/shakespeare.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 dist/
 *.egg-info/
 bench/shakespeare.txt
+.coverage

--- a/toolz/compatibility.py
+++ b/toolz/compatibility.py
@@ -19,6 +19,7 @@ if PY3:
     iteritems = operator.methodcaller('items')
     iterkeys = operator.methodcaller('keys')
     itervalues = operator.methodcaller('values')
+    from collections.abc import Sequence
 else:
     range = xrange
     reduce = reduce
@@ -30,3 +31,4 @@ else:
     iteritems = operator.methodcaller('iteritems')
     iterkeys = operator.methodcaller('iterkeys')
     itervalues = operator.methodcaller('itervalues')
+    from collections import Sequence

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -5,15 +5,8 @@ import operator
 from functools import partial
 from random import Random
 from toolz.compatibility import (map, filterfalse, zip, zip_longest, iteritems,
-                                 filter)
+                                 filter, Sequence)
 from toolz.utils import no_default
-
-try:
-    # Python 3
-    from collections.abc import Sequence
-except ImportError:  # pragma: no cover
-    # Python 2.7
-    from collections import Sequence
 
 
 __all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -8,6 +8,13 @@ from toolz.compatibility import (map, filterfalse, zip, zip_longest, iteritems,
                                  filter)
 from toolz.utils import no_default
 
+try:
+    # Python 3
+    from collections.abc import Sequence
+except ImportError:
+    # Python 2.7
+    from collections import Sequence
+
 
 __all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
            'unique', 'isiterable', 'isdistinct', 'take', 'drop', 'take_nth',
@@ -391,7 +398,7 @@ def nth(n, seq):
     >>> nth(1, 'ABC')
     'B'
     """
-    if isinstance(seq, (tuple, list, collections.Sequence)):
+    if isinstance(seq, (tuple, list, Sequence)):
         return seq[n]
     else:
         return next(itertools.islice(seq, n, None))

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -11,7 +11,7 @@ from toolz.utils import no_default
 try:
     # Python 3
     from collections.abc import Sequence
-except ImportError:
+except ImportError:  # pragma: no cover
     # Python 2.7
     from collections import Sequence
 


### PR DESCRIPTION
Running pytest on master with Python 3.7.0:
```
=============================================== test session starts ================================================
platform darwin -- Python 3.7.0, pytest-3.8.1, py-1.5.4, pluggy-0.7.1
...
================================================= warnings summary =================================================
/private/tmp/toolz/toolz/itertoolz.py:394: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  if isinstance(seq, (tuple, list, collections.Sequence)):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================================== 199 passed, 1 warnings in 8.34 seconds ======================================
```

No warning with this branch:
```
============================================ 199 passed in 7.91 seconds ============================================
```


Also Git ignore a file created when running tests to make sure it isn't committed by mistake.