### PR TITLE
Faster join

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -875,14 +875,14 @@ def join(leftkey, leftseq, rightkey, rightseq,
 
     d = groupby(leftkey, leftseq)
 
-    if (left_default == no_default) and (right_default == no_default):
+    if left_default == no_default and right_default == no_default:
         # Inner Join
         for item in rightseq:
             key = rightkey(item)
             if key in d:
                 for left_match in d[key]:
                     yield (left_match, item)
-    elif (left_default != no_default) and (right_default == no_default):
+    elif left_default != no_default and right_default == no_default:
         # Right Join
         for item in rightseq:
             key = rightkey(item)
@@ -891,7 +891,7 @@ def join(leftkey, leftseq, rightkey, rightseq,
                     yield (left_match, item)
             else:
                 yield (left_default, item)
-    elif (right_default != no_default):
+    elif right_default != no_default:
         seen_keys = set()
 
         if left_default == no_default:

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -861,8 +861,9 @@ def join(leftkey, leftseq, rightkey, rightseq,
     Usually the key arguments are callables to be applied to the sequences.  If
     the keys are not obviously callable then it is assumed that indexing was
     intended, e.g. the following is a legal change.
-    The join is implemented as a hash join and the keys of leftseq must be hashable.
-    Additionally, if right_default is defined, then keys of rightseq must also be hashable.
+    The join is implemented as a hash join and the keys of leftseq must be
+    hashable. Additionally, if right_default is defined, then keys of rightseq
+    must also be hashable.
 
     >>> # result = join(second, friends, first, cities)
     >>> result = join(1, friends, 0, cities)  # doctest: +SKIP

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -874,14 +874,14 @@ def join(leftkey, leftseq, rightkey, rightseq,
 
     d = groupby(leftkey, leftseq)
 
-    if (left_default is no_default) and (right_default is no_default):
+    if (left_default == no_default) and (right_default == no_default):
         # Inner Join
         for item in rightseq:
             key = rightkey(item)
             if key in d:
                 for left_match in d[key]:
                     yield (left_match, item)
-    elif (left_default is not no_default) and (right_default is no_default):
+    elif (left_default != no_default) and (right_default == no_default):
         # Right Join
         for item in rightseq:
             key = rightkey(item)
@@ -890,17 +890,17 @@ def join(leftkey, leftseq, rightkey, rightseq,
                     yield (left_match, item)
             else:
                 yield (left_default, item)
-    elif (right_default is not no_default):
+    elif (right_default != no_default):
         seen_keys = set()
 
-        if left_default is no_default:
+        if left_default == no_default:
             # Left Join
             for item in rightseq:
                 key = rightkey(item)
                 seen_keys.add(key)
                 if key in d:
                     for left_match in d[key]:
-                        yield(left_match, item)
+                        yield (left_match, item)
         else:
             # Full Join
             for item in rightseq:

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -893,12 +893,13 @@ def join(leftkey, leftseq, rightkey, rightseq,
                 yield (left_default, item)
     elif right_default != no_default:
         seen_keys = set()
+        seen = seen_keys.add
 
         if left_default == no_default:
             # Left Join
             for item in rightseq:
                 key = rightkey(item)
-                seen_keys.add(key)
+                seen(key)
                 if key in d:
                     for left_match in d[key]:
                         yield (left_match, item)
@@ -906,7 +907,7 @@ def join(leftkey, leftseq, rightkey, rightseq,
             # Full Join
             for item in rightseq:
                 key = rightkey(item)
-                seen_keys.add(key)
+                seen(key)
                 if key in d:
                     for left_match in d[key]:
                         yield (left_match, item)

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -875,13 +875,11 @@ def join(leftkey, leftseq, rightkey, rightseq,
     for item in rightseq:
         key = rightkey(item)
         seen_keys.add(key)
-        try:
-            left_matches = d[key]
-            for match in left_matches:
-                yield (match, item)
-        except KeyError:
-            if not left_default_is_no_default:
-                yield (left_default, item)
+        if key in d:
+            for left_match in d[key]:
+                yield (left_match, item)
+        elif not left_default_is_no_default:
+            yield (left_default, item)
 
     if right_default != no_default:
         for key, matches in d.items():

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -882,7 +882,7 @@ def join(leftkey, leftseq, rightkey, rightseq,
             yield (left_default, item)
 
     if right_default != no_default:
-        for key, matches in d.items():
+        for key, matches in iteritems(d):
             if key not in seen_keys:
                 for match in matches:
                     yield (match, right_default)


### PR DESCRIPTION
Make join much faster by avoiding the exception handling.

```
# Python 2.7 with len(leftseq) = 1000 and len(rightseq) = 10000
# 30% of the keys in the left side appear in the right side.
# first run is old join, second run is new join
Inner Join
100 loops, best of 3: 12.6 ms per loop
100 loops, best of 3: 5.44 ms per loop
Left Join
100 loops, best of 3: 17 ms per loop
100 loops, best of 3: 6.68 ms per loop
Right Join
100 loops, best of 3: 12.8 ms per loop
100 loops, best of 3: 5.74 ms per loop
Full Join
100 loops, best of 3: 17.5 ms per loop
100 loops, best of 3: 6.94 ms per loop
```

Also use iteritems(d) instead of d.items() to avoid creating a copy of left items on Python 2.