### PR TITLE
Add hint for groupby to documentation

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -89,6 +89,8 @@ def groupby(key, seq):
      'M': [{'gender': 'M', 'name': 'Bob'},
            {'gender': 'M', 'name': 'Charlie'}]}
 
+    Not to be confused with ``itertools.groupby``
+
     See Also:
         countby
     """


### PR DESCRIPTION
Same name, but does something different. Might be confusing, so let's
warn users explicitly.