### PR TITLE
Fix wrong docstring for unzip()

### DIFF
--- a/toolz/sandbox/core.py
+++ b/toolz/sandbox/core.py
@@ -105,7 +105,7 @@ def unzip(seq):
     [1, 2]
 
     Unlike the naive implementation ``def unzip(seq): zip(*seq)`` this
-    implementation can handle a finite sequence of infinite sequences.
+    implementation can handle an infinite sequence ``seq``.
 
     Caveats:
 
@@ -113,7 +113,8 @@ def unzip(seq):
       of auxiliary storage if the resulting iterators are consumed at
       different times.
 
-    * The top level sequence cannot be infinite.
+    * The inner sequence cannot be infinite. In Python 3 ``zip(*seq)`` can be
+      used if ``seq`` is a finite sequence of infinite sequences.
 
     """
 


### PR DESCRIPTION
The current version of unzip() works only if the inner sequence is
finite, but in Python 3 zip() can be used. See also comment in #239.