### PR TITLE
Faster itertoolz.update_in

### DIFF
--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -7,6 +7,7 @@ __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
            'valfilter', 'keyfilter', 'itemfilter',
            'assoc', 'dissoc', 'assoc_in', 'update_in', 'get_in')
 
+
 def _get_factory(f, kwargs):
     factory = kwargs.pop('factory', dict)
     if kwargs:
@@ -287,6 +288,7 @@ def update_in(d, keys, func, default=None, factory=dict):
     else:
         inner[k] = func(default)
     return rv
+
 
 def get_in(keys, coll, default=None, no_default=False):
     """ Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.

--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -7,7 +7,6 @@ __all__ = ('merge', 'merge_with', 'valmap', 'keymap', 'itemmap',
            'valfilter', 'keyfilter', 'itemfilter',
            'assoc', 'dissoc', 'assoc_in', 'update_in', 'get_in')
 
-
 def _get_factory(f, kwargs):
     factory = kwargs.pop('factory', dict)
     if kwargs:
@@ -266,16 +265,28 @@ def update_in(d, keys, func, default=None, factory=dict):
     >>> update_in({1: 'foo'}, [2, 3, 4], inc, 0)
     {1: 'foo', 2: {3: {4: 1}}}
     """
-    assert len(keys) > 0
-    k, ks = keys[0], keys[1:]
-    if ks:
-        return assoc(d, k, update_in(d[k] if (k in d) else factory(),
-                                     ks, func, default, factory),
-                     factory)
-    else:
-        innermost = func(d[k]) if (k in d) else func(default)
-        return assoc(d, k, innermost, factory)
+    ks = iter(keys)
+    k = next(ks)
 
+    rv = inner = factory()
+    rv.update(d)
+
+    for key in ks:
+        if k in d:
+            d = d[k]
+            dtemp = factory()
+            dtemp.update(d)
+        else:
+            d = dtemp = factory()
+
+        inner[k] = inner = dtemp
+        k = key
+
+    if k in d:
+        inner[k] = func(d[k])
+    else:
+        inner[k] = func(default)
+    return rv
 
 def get_in(keys, coll, default=None, no_default=False):
     """ Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.


### PR DESCRIPTION
The existing, recursive, form of update_in is unnecessarily slow.  This borrows the non-recursive implementation from cytoolz and shows a good performance boost.

```python
from toolz import update_in, update_in2
keys1 = list(reversed([list(range(i+100)) for i in range(100)]))
keys2 = list(reversed([list(range(i)) for i in range(1, 11)]))

# A custom assoc_in function which simply allows me to 
# change which update_in function is called.

%%timeit
d = {}
for x in keys1:
    d = assoc_in(update_in, d, x, 42)
# update_in (keys1)
26.3 ms ± 668 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# update_in2 (keys1)
4.96 ms ± 62.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# update_in (keys2)
86.7 µs ± 2.48 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
# update_in2 (keys2)
21.4 µs ± 118 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```