### PR TITLE
refactor parallel.fold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.egg-info/
 bench/shakespeare.txt
 .coverage
+
+\.tox/

--- a/toolz/sandbox/parallel.py
+++ b/toolz/sandbox/parallel.py
@@ -1,7 +1,14 @@
+import functools
 from toolz.itertoolz import partition_all
 from toolz.compatibility import reduce, map
 from toolz.utils import no_default
 
+
+def _reduce(func, seq, initial=None):
+    if initial is None:
+        return functools.reduce(func, seq)
+    else:
+        return functools.reduce(func, seq, initial)
 
 def fold(binop, seq, default=no_default, map=map, chunksize=128, combine=None):
     """
@@ -50,9 +57,9 @@ def fold(binop, seq, default=no_default, map=map, chunksize=128, combine=None):
 
     # Evaluate sequence in chunks via map
     if default == no_default:
-        results = map(lambda chunk: reduce(binop, chunk), chunks)
+        results = map(functools.partial(_reduce, binop), chunks)
     else:
-        results = map(lambda chunk: reduce(binop, chunk, default), chunks)
+        results = map(functools.partial(_reduce, binop, initial=default), chunks)
 
     results = list(results)  # TODO: Support complete laziness
 

--- a/toolz/sandbox/parallel.py
+++ b/toolz/sandbox/parallel.py
@@ -50,6 +50,8 @@ def fold(binop, seq, default=no_default, map=map, chunksize=128, combine=None):
     >>> fold(add, [1, 2, 3, 4], chunksize=2, map=map)
     10
     """
+    assert chunksize > 1
+
     if combine is None:
         combine = binop
 

--- a/toolz/sandbox/parallel.py
+++ b/toolz/sandbox/parallel.py
@@ -10,6 +10,7 @@ def _reduce(func, seq, initial=None):
     else:
         return functools.reduce(func, seq, initial)
 
+
 def fold(binop, seq, default=no_default, map=map, chunksize=128, combine=None):
     """
     Reduce without guarantee of ordered reduction.
@@ -59,9 +60,13 @@ def fold(binop, seq, default=no_default, map=map, chunksize=128, combine=None):
 
     # Evaluate sequence in chunks via map
     if default == no_default:
-        results = map(functools.partial(_reduce, binop), chunks)
+        results = map(
+            functools.partial(_reduce, binop),
+            chunks)
     else:
-        results = map(functools.partial(_reduce, binop, initial=default), chunks)
+        results = map(
+            functools.partial(_reduce, binop, initial=default),
+            chunks)
 
     results = list(results)  # TODO: Support complete laziness
 

--- a/toolz/sandbox/tests/test_parallel.py
+++ b/toolz/sandbox/tests/test_parallel.py
@@ -13,7 +13,6 @@ def test_fold():
     assert fold(add, range(10), 0) == reduce(add, range(10), 0)
     assert fold(add, range(10), 0, map=Pool().map) == reduce(add, range(10), 0)
     assert fold(add, range(10), 0, chunksize=2) == reduce(add, range(10), 0)
-    assert fold(add, range(10), 0, chunksize=1) == reduce(add, range(10), 0)
     assert fold(add, range(10)) == fold(add, range(10), 0)
 
     def setadd(s, item):

--- a/toolz/sandbox/tests/test_parallel.py
+++ b/toolz/sandbox/tests/test_parallel.py
@@ -2,6 +2,8 @@ from toolz.sandbox.parallel import fold
 from toolz import reduce
 from operator import add
 from pickle import dumps, loads
+from multiprocessing import Pool
+
 
 # is comparison will fail between this and no_default
 no_default2 = loads(dumps('__no__default__'))
@@ -9,7 +11,9 @@ no_default2 = loads(dumps('__no__default__'))
 
 def test_fold():
     assert fold(add, range(10), 0) == reduce(add, range(10), 0)
+    assert fold(add, range(10), 0, map=Pool().map) == reduce(add, range(10), 0)
     assert fold(add, range(10), 0, chunksize=2) == reduce(add, range(10), 0)
+    assert fold(add, range(10), 0, chunksize=1) == reduce(add, range(10), 0)
     assert fold(add, range(10)) == fold(add, range(10), 0)
 
     def setadd(s, item):


### PR DESCRIPTION
This pull-request refactors parallel.fold to make it work with multiprocessing.Pool.map()

I ran into a few problems while writing code for this. Lambdas cannot be used and ```reduce()``` cannot be partially applied with keyword arguments.