### PR TITLE
DOC/BUG: fix import so in memory split-apply-combine example runs

### DIFF
--- a/doc/source/streaming-analytics.rst
+++ b/doc/source/streaming-analytics.rst
@@ -81,8 +81,8 @@ groups.
 
 .. code::
 
-   >>> from toolz import groupby, valmap, compose
-   >>> from toolz.curried import get, pluck
+   >>> from toolz import compose
+   >>> from toolz.curried import get, pluck, groupby, valmap
 
    >>> groupby(get(3), accounts)
    {'F': [(1, 'Alice', 100, 'F'), (5, 'Edith', 300, 'F')],


### PR DESCRIPTION
I believe there's a bug in the [In Memory Split-Apply-Combine](https://toolz.readthedocs.io/en/latest/streaming-analytics.html#in-memory-split-apply-combine) section regarding where to import `groupby` and `valmap` from.

If I run
```
from toolz import compose, pipe
from toolz.curried import get, pluck


def run_working(accounts):
    from toolz.curried import groupby, valmap
    return pipe(accounts, groupby(get(3)), valmap(compose(sum, pluck(2))))


def run_borken(accounts):
    # TypeError: groupby() missing 1 required positional argument: 'seq'
    from toolz import groupby, valmap
    return pipe(accounts, groupby(get(3)), valmap(compose(sum, pluck(2))))


if __name__ == '__main__':
    accounts = [
        # id, name, balance, gender
        (1, 'Alice', 100, 'F'),
        (2, 'Bob', 200, 'M'),
        (3, 'Charlie', 150, 'M'),
        (4, 'Dennis', 50, 'M'),
        (5, 'Edith', 300, 'F'),
    ]
    print('run_working(accounts):')
    print(run_working(accounts))
    print('run_borken(accounts):')
    print(run_borken(accounts))
```

I see
```
run_working(accounts):
{'F': 400, 'M': 400}
run_borken(accounts):
Traceback (most recent call last):
  File "script.py", line 29, in <module>
    print(run_borken(accounts))
  File "script.py", line 14, in run_borken
    return pipe(accounts, groupby(get(3)), valmap(compose(sum, pluck(2))))
TypeError: groupby() missing 1 required positional argument: 'seq'
```