### PR TITLE
Revert 899a932, which worked around a bug in pypy3<2.5

### DIFF
--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -1,6 +1,4 @@
 import inspect
-import platform
-
 from toolz.functoolz import (thread_first, thread_last, memoize, curry,
                              compose, compose_left, pipe, complement, do, juxt,
                              flip, excepts, apply)
@@ -230,12 +228,10 @@ def test_curry_kwargs():
     def h(x, func=int):
         return func(x)
 
-    if platform.python_implementation() != 'PyPy'\
-            or platform.python_version_tuple()[0] != '3':  # Bug on PyPy3<2.5
-        # __init__ must not pick func as positional arg
-        assert curry(h)(0.0) == 0
-        assert curry(h)(func=str)(0.0) == '0.0'
-        assert curry(h, func=str)(0.0) == '0.0'
+    # __init__ must not pick func as positional arg
+    assert curry(h)(0.0) == 0
+    assert curry(h)(func=str)(0.0) == '0.0'
+    assert curry(h, func=str)(0.0) == '0.0'
 
 
 def test_curry_passes_errors():


### PR DESCRIPTION
This issue has been fixed for years.  Thanks for the reminder @Digenis https://github.com/pytoolz/toolz/pull/217#issuecomment-486610352.