### PR TITLE
Breakpoint sig

### DIFF
--- a/toolz/__init__.py
+++ b/toolz/__init__.py
@@ -8,14 +8,14 @@ from .recipes import *
 
 from .compatibility import map, filter
 
-from . import sandbox
-
 from functools import partial, reduce
 
 sorted = sorted
 
 # Aliases
 comp = compose
+
+from . import curried, sandbox
 
 functoolz._sigs.create_signature_registry()
 

--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -237,6 +237,8 @@ module_info[builtins]['exec'] = [
 
 if PY3:  # pragma: py2 no cover
     module_info[builtins].update(
+        breakpoint=[
+            lambda *args, **kws: None],
         bytes=[
             lambda: None,
             lambda int: None,

--- a/toolz/tests/test_inspect_args.py
+++ b/toolz/tests/test_inspect_args.py
@@ -402,7 +402,6 @@ def test_introspect_builtin_modules():
             blacklist.add(getattr(mod, attr))
 
     add_blacklist(builtins, 'basestring')
-    add_blacklist(builtins, 'breakpoint')
     add_blacklist(builtins, 'NoneType')
     add_blacklist(builtins, '__metaclass__')
     add_blacklist(builtins, 'sequenceiterator')


### PR DESCRIPTION
This is a better way to handle https://github.com/pytoolz/cytoolz/issues/122

While we're add it, let's add `curried` to the main `toolz` namespace.  I thought we already did this!