### PR TITLE
A function to just raise an exception.

### DIFF
--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -710,6 +710,14 @@ def do(func, x):
     return x
 
 
+def just_raise(exception):
+    """ Just raises the exception given. """
+    def inner():
+        raise exception
+
+    return inner
+
+
 @curry
 def flip(func, a, b):
     """ Call the function call with the arguments flipped


### PR DESCRIPTION
This is because you can't easily use a lambda to raise an exception, and sometimes the need arises to translate an exception X into exception Y when using `toolz.excepts`.