### PR TITLE
Add auto-publishing to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,15 @@ script:
 after_success:
     - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install coveralls --use-mirrors ; coveralls ; fi
 
+# publish new version to pypi
+deploy:
+  provider: pypi
+  skip_existing: true
+  on:
+    tags: true
+  user: $PYPI_USER
+  password: $PYPI_PASSWORD
+  distributions: "sdist bdist_wheel"
+
 notifications:
   email: false


### PR DESCRIPTION
This adds auto-publishing to PyPI. It also adds publishing wheels and closes #466.

Currently, it seems that new versions are published manually, but this change will automatically publish new version on every Git tag and will contain both source and wheels. Because module is pure-Python, wheels can be for more Python versions so there isn't any need for complicated build scripts.

To enable this, `PYPI_USER` and `PYPI_PASSWORD` should be set in Travis CI config as secret/private environment variables. First option is to just set it to PyPI username and password, the second one (which is recommended and more secure), is to set username to `__token__` and then set password to PyPI token as described [here](https://pypi.org/help/#apitoken).