### PR TITLE
Add tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist =
+    py35
+    py36
+    py37
+    py38
+    py39
+    pypy3
+
+skip_missing_interpreters = true
+
+
+[testenv]
+deps = pytest
+commands = py.test {posargs}


### PR DESCRIPTION
This pull request adds a tox config file to make new contributions easier.
Listed are environments for Python 3.5, 3.6, 3.7, 3.8, 3.9, and pypy3.

_tox aims to automate and standardize testing in Python._ 

To use:
```
$ pip install -U tox
$ tox
# for parallel testing
$ tox -p 4
```

More information at:
https://tox.readthedocs.io/
