### PR TITLE
Add dictionary intersection

### DIFF
--- a/toolz/tests/test_dicttoolz.py
+++ b/toolz/tests/test_dicttoolz.py
@@ -152,6 +152,12 @@ class TestDict(object):
                           factory=lambda: defaultdict(int)) == {1: 2, 2: 3})
         assert raises(TypeError, lambda: merge(D({1: 2}), D({2: 3}), factoryy=dict))
 
+    def test_intersect(self):
+        D, kw = self.D, self.kw
+        assert intersect({0:1, 1:2}, {0:2}) == {0: (1, 2)}
+        assert (intersect(D({'a': 1, 'b': 2, 'c': 3}), D({'b': 'a', 'c': 'z'}), **kw) ==
+                D({'b': (2, 'a'), 'c': (3, 'z')}))
+
 
 class defaultdict(_defaultdict):
     def __eq__(self, other):


### PR DESCRIPTION
An efficient way to intersect dictionaries based on their keys. The motivating case was to replace the below line with something nicer and more general.
```python
rv = {i: (d1[i], d2[i]) for i in d1.keys() & d2.keys()}
```
This function is generalized to compute the intersection of more than two dictionaries and handle generic mappings.

@eriknw, I think other operations on dictionary views would be useful. However, those other operations don't seem to fit the calling conventions for the functions here because they are only well-defined for two dictionaries (operations like difference, symmetric difference, etc). Union would be similar to merge, but preserves all the values from each input dictionary.