### PR TITLE
Add apply and compose_left to do/source/api.rst

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -59,8 +59,10 @@ Functoolz
 .. currentmodule:: toolz.functoolz
 
 .. autosummary::
+   apply
    complement
    compose
+   compose_left
    curry
    do
    excepts
@@ -79,13 +81,13 @@ Dicttoolz
 
 .. autosummary::
    assoc
-   dissoc
    assoc_in
+   dissoc
    get_in
-   keyfilter
-   keymap
    itemfilter
    itemmap
+   keyfilter
+   keymap
    merge
    merge_with
    update_in


### PR DESCRIPTION
Also, alphabetize the API list for dicttoolz.

Fixes https://github.com/pytoolz/toolz/issues/470