### PR TITLE
Add nonunique.

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -274,6 +274,30 @@ def unique(seq, key=None):
                 yield item
 
 
+def nonunique(seq, key=None):
+    """Return only nonunique elements of a sequence.
+
+    >>> tuple(nonunique((1, 2, 3, 1)))
+    (1,)
+    >>> tuple(nonunique((1, 2, 3)))
+    ()
+    """
+    seen = set()
+    seen_add = seen.add
+    if key is None:
+        for item in seq:
+            if item in seen:
+                yield item
+            seen_add(item)
+    else:
+        for item in seq:
+            val = key(item)
+            if val in seen:
+                yield item
+            seen_add(val)
+
+
+
 def isiterable(x):
     """ Is x iterable?
 
@@ -305,12 +329,8 @@ def isdistinct(seq):
     True
     """
     if iter(seq) is seq:
-        seen = set()
-        seen_add = seen.add
-        for item in seq:
-            if item in seen:
-                return False
-            seen_add(item)
+        for item in nonunique(seq):
+            return False
         return True
     else:
         return len(seq) == len(set(seq))

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -4,7 +4,7 @@ from toolz.utils import raises
 from functools import partial
 from random import Random
 from pickle import dumps, loads
-from toolz.itertoolz import (remove, groupby, merge_sorted,
+from toolz.itertoolz import (nonunique, remove, groupby, merge_sorted,
                              concat, concatv, interleave, unique,
                              isiterable, getter,
                              mapcat, isdistinct, first, second,
@@ -104,6 +104,12 @@ def test_unique():
     assert tuple(unique((1, 2, 1, 3))) == (1, 2, 3)
     assert tuple(unique((1, 2, 3), key=iseven)) == (1, 2)
 
+
+def test_nonunique():
+    assert tuple(nonunique((1, 2, 3))) == ()
+    assert tuple(nonunique((1, 2, 1, 3, 1))) == (1, 1)
+    assert tuple(nonunique((1, 2, 3, 4), key=iseven)) == (3, 4)
+    
 
 def test_isiterable():
     assert isiterable([1, 2, 3]) is True


### PR DESCRIPTION
`itertoolz.unique` yields the never before seen elements of sequence.
`nonunique` is the complement, yielding the already seen elements of a sequence.

This is incredibly useful for finding duplicates in a sequence.
```python
>>> tuple(nonunique([1, 2, 3, 4, 5, 1, 2, 3]))
(1, 2, 3)
```

This isn't really a new feature to itertoolz, but instead exposes an already existing feature. `isdistinct` already had this logic, but instead of returning True/False, I return the already seen elements as they are encountered. This PR simply moves the logic into its own function.

ping: @eriknw 