### PR TITLE
Add composition as an operator via a new `composable` class

### DIFF
--- a/toolz/curried/__init__.py
+++ b/toolz/curried/__init__.py
@@ -29,6 +29,7 @@ from toolz import (
     apply,
     comp,
     complement,
+    composable,
     compose,
     compose_left,
     concat,

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -12,8 +12,8 @@ PYPY = hasattr(sys, 'pypy_version_info') and sys.version_info[0] > 2
 
 
 __all__ = ('identity', 'apply', 'thread_first', 'thread_last', 'memoize',
-           'compose', 'compose_left', 'pipe', 'complement', 'juxt', 'do',
-           'curry', 'flip', 'excepts')
+           'composable', 'compose', 'compose_left', 'pipe', 'complement',
+           'juxt', 'do', 'curry', 'flip', 'excepts')
 
 PYPY = hasattr(sys, 'pypy_version_info')
 

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -5,7 +5,6 @@ from importlib import import_module
 from operator import attrgetter, not_
 from textwrap import dedent
 from types import MethodType
-from typing import Callable, Generic, TypeVar
 
 from .utils import no_default
 
@@ -17,9 +16,6 @@ __all__ = ('identity', 'apply', 'thread_first', 'thread_last', 'memoize',
            'curry', 'flip', 'excepts')
 
 PYPY = hasattr(sys, 'pypy_version_info')
-
-T = TypeVar('T')
-S = TypeVar('S')
 
 
 def identity(x):
@@ -475,7 +471,7 @@ def memoize(func, cache=None, key=None):
     return memof
 
 
-class composable(Generic[T]):
+class composable:
     """A composable function using the pipe operator ``|``.
 
     Can be used as a decorator:
@@ -497,26 +493,29 @@ class composable(Generic[T]):
     See Also:
         compose
     """
+    __slots__ = ('func',)
 
-    # TODO: when `typing_extensions` becomes a dependency for this toolz or we decide
-    # to support Python 3.10+ only, type annotations can be much improved here.
+    # TODO: when `typing_extensions` becomes a dependency for this toolz or we
+    # decide to support Python 3.10+ only, we can write complete type
+    # annotations here.
     #
     # First, we can make `composable` inherit from `Generic[P, T]`, where
     # `P = (typing/typing_extensions).ParamSpec('P')`.
     #
-    # Second, the annotation for `call` should be replaced with `Callable[P, T]`
+    # Second, the annotation for `call` should be written as
+    # `Callable[P, T]`
     #
     # Third, the definition for `__call__` can be written as
     # `def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:`
     #
     # Finally, `__or__` must return `composable[P, S]`.
-    def __init__(self, call: Callable[..., T]) -> None:
-        self.call = call
+    def __init__(self, func):
+        self.func = func
 
-    def __call__(self, *args, **kwargs) -> T:
-        return self.call(*args, **kwargs)
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
 
-    def __or__(self, other: Callable[[T], S]) -> 'composable[S]':
+    def __or__(self, other):
         return composable(compose(other, self))
 
 

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -488,6 +488,9 @@ class _Composable:
     def __or__(self, other):
         return compose(other, self)
 
+    def __ror__(self, other):
+        return compose(self, other)
+
 
 class composable(_Composable):
     """ A composable function using the pipe operator ``|``.

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -471,8 +471,26 @@ def memoize(func, cache=None, key=None):
     return memof
 
 
-class composable:
-    """A composable function using the pipe operator ``|``.
+class _Composable:
+    """ Base class for functions supporting composition via the pipe operator.
+
+    See Also:
+        composable
+        compose
+    """
+    # TODO: when `typing_extensions` becomes a dependency for this toolz or we
+    # decide to support Python 3.10+ only, we can write complete type
+    # annotations here.
+    #
+    # We can make `_Composable` inherit from `Generic[P, T]`, where
+    # `P = (typing/typing_extensions).ParamSpec('P')`. In this case,
+    # `__or__` must accept a `Callable[[T], S]` and return `composable[P, S]`.
+    def __or__(self, other):
+        return compose(other, self)
+
+
+class composable(_Composable):
+    """ A composable function using the pipe operator ``|``.
 
     Can be used as a decorator:
 
@@ -493,33 +511,14 @@ class composable:
     See Also:
         compose
     """
-    __slots__ = ('func',)
-
-    # TODO: when `typing_extensions` becomes a dependency for this toolz or we
-    # decide to support Python 3.10+ only, we can write complete type
-    # annotations here.
-    #
-    # First, we can make `composable` inherit from `Generic[P, T]`, where
-    # `P = (typing/typing_extensions).ParamSpec('P')`.
-    #
-    # Second, the annotation for `call` should be written as
-    # `Callable[P, T]`
-    #
-    # Third, the definition for `__call__` can be written as
-    # `def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:`
-    #
-    # Finally, `__or__` must return `composable[P, S]`.
-    def __init__(self, func):
-        self.func = func
+    def __init__(self, __func):
+        self.__func = __func
 
     def __call__(self, *args, **kwargs):
-        return self.func(*args, **kwargs)
-
-    def __or__(self, other):
-        return composable(compose(other, self))
+        return self.__func(*args, **kwargs)
 
 
-class Compose(object):
+class Compose(_Composable):
     """ A composition of functions
 
     See Also:

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -691,6 +691,9 @@ def test_composable():
     # check multiple composition via pipe operator
     assert (composable(double) | inc | iseven | str)(3) == "False"
 
+    # check right composition
+    assert (double | composable_inc)(2) == 5
+
     # check decorator
     @composable
     def dec(i):

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -571,27 +571,6 @@ def test_compose():
         assert compose(*compose_args)(*args, **kw) == expected
 
 
-def test_composable():
-    composable_inc = composable(inc)
-
-    # check direct call
-    assert composable_inc(0) == 1
-
-    # check composition via pipe operator
-    assert (composable_inc | double)(0) == 2
-
-    # check multiple composition via pipe operator
-    assert (composable(double) | inc | iseven | str)(3) == "False"
-
-    # check decorator
-    @composable
-    def dec(i):
-        return i - 1
-
-    composition = dec | str
-    assert composition(3) == "2"
-
-
 def test_compose_metadata():
 
     # Define two functions with different names
@@ -698,6 +677,36 @@ def generate_compose_left_test_cases():
 def test_compose_left():
     for (compose_left_args, args, kw, expected) in generate_compose_left_test_cases():
         assert compose_left(*compose_left_args)(*args, **kw) == expected
+
+
+def test_composable():
+    composable_inc = composable(inc)
+
+    # check direct call
+    assert composable_inc(0) == 1
+
+    # check composition via pipe operator
+    assert (composable_inc | double)(0) == 2
+
+    # check multiple composition via pipe operator
+    assert (composable(double) | inc | iseven | str)(3) == "False"
+
+    # check decorator
+    @composable
+    def dec(i):
+        return i - 1
+
+    composition = dec | str
+    assert composition(3) == "2"
+
+
+def test_composable_compose():
+    # check that functions created via `compose` are composable via `|`
+    composed = compose(double, inc)
+    assert composed(3) == 8
+
+    composed2 = composed | str
+    assert composed2(3) == "8"
 
 
 def test_pipe():

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -1,6 +1,6 @@
 import inspect
 import toolz
-from toolz.functoolz import (thread_first, thread_last, memoize, curry,
+from toolz.functoolz import (thread_first, thread_last, memoize, curry, composable,
                              compose, compose_left, pipe, complement, do, juxt,
                              flip, excepts, apply)
 from operator import add, mul, itemgetter
@@ -569,6 +569,27 @@ def generate_compose_test_cases():
 def test_compose():
     for (compose_args, args, kw, expected) in generate_compose_test_cases():
         assert compose(*compose_args)(*args, **kw) == expected
+
+
+def test_composable():
+    composable_inc = composable(inc)
+
+    # check direct call
+    assert composable_inc(0) == 1
+
+    # check composition via pipe operator
+    assert (composable_inc | double)(0) == 2
+
+    # check multiple composition via pipe operator
+    assert (composable(double) | inc | iseven | str)(3) == "False"
+
+    # check decorator
+    @composable
+    def dec(i):
+        return i - 1
+
+    composition = dec | str
+    assert composition(3) == "2"
 
 
 def test_compose_metadata():


### PR DESCRIPTION
## Overview

Add a new `composable` class for functions that can be composed via the pipe operator. This idea originated from and was discussed in https://github.com/pytoolz/toolz/issues/523.

In this implementation, I decided not to include any type-annotations. This is because most of (all?) the project lacks type-annotations. Adding such annotations is probably a PR of its own.

## Future work

1. Make other tools classes inherit from `composable` as well, like `curry`, `juxt`, and `excepts`, as suggested in https://github.com/pytoolz/toolz/issues/523#issuecomment-1037008717.
2. We can probably make something very similar for the `pipe` function by creating a `pipeable` class.