### PR TITLE
Use defaultdict for collecting intermediate values in merge_with

### DIFF
--- a/toolz/dicttoolz.py
+++ b/toolz/dicttoolz.py
@@ -1,4 +1,5 @@
 import operator
+import collections
 from functools import reduce
 from collections.abc import Mapping
 
@@ -58,14 +59,15 @@ def merge_with(func, *dicts, **kwargs):
         dicts = dicts[0]
     factory = _get_factory(merge_with, kwargs)
 
-    result = factory()
+    values = collections.defaultdict(lambda: [].append)
     for d in dicts:
         for k, v in d.items():
-            if k not in result:
-                result[k] = [v]
-            else:
-                result[k].append(v)
-    return valmap(func, result, factory)
+            values[k](v)
+
+    result = factory()
+    for k, v in values.items():
+        result[k] = func(v.__self__)
+    return result
 
 
 def valmap(func, d, factory=dict):


### PR DESCRIPTION
This approach also avoids calling factory() twice. It combines the ideas of `itertoolz.groupby` and `cytoolz.merge_with`.

Best of all: there is a small performance gain:
```python
In [2]: rand_d = [dict(zip(range(50), range(50))) for i in range(100)]

In [12]: %timeit merge_with(max, rand_d)
527 µs ± 14.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [13]: %timeit toolz.merge_with(max, rand_d)
730 µs ± 24.2 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```