### PR TITLE
Fix Tlz error in Python 3.11 (alpha)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,18 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "pypy-3.6", "pypy-3.7", "pypy-3.8"]
+        python-version:
+          - "3.5"
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11.0-alpha - 3.11.0"
+          - "pypy-3.6"
+          - "pypy-3.7"
+          - "pypy-3.8"
+          - "pypy-3.9"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/tlz/_build_tlz.py
+++ b/tlz/_build_tlz.py
@@ -96,6 +96,8 @@ class TlzSpec(object):
         self.cached = None
         self.parent = None
         self.has_location = False
+        # Added in Python 3.11 (to improve circular imports or their errors?)
+        self._uninitialized_submodules = []
 
 
 tlz_loader = TlzLoader()


### PR DESCRIPTION
Fixes #528.

xref: https://github.com/python/cpython/pull/27338 and https://github.com/python/cpython/issues/88880

I'm a little surprised that the code in CPython _assumes_ that all module specs have `_uninitialized_submodules`.  Maybe we should push for a change upstream, or maybe we should inherit from `ModuleSpec` to improve future-compatibility.  Actually, yeah, I'll try to just use `ModuleSpec` directly instead of `TlzSpec`.