### PR TITLE
Make import times significantly faster

### DIFF
--- a/toolz/curried/operator.py
+++ b/toolz/curried/operator.py
@@ -2,22 +2,21 @@ from __future__ import absolute_import
 
 import operator
 
-from toolz.functoolz import curry, num_required_args, has_keywords
+from toolz.functoolz import curry
 
 
-def should_curry(f):
-    num = num_required_args(f)
-    return num is None or num > 1 or num == 1 and has_keywords(f) is not False
-
-
+# Tests will catch if/when this needs updated
+IGNORE = {
+    "__abs__", "__index__", "__inv__", "__invert__", "__neg__", "__not__",
+    "__pos__", "_abs", "abs", "attrgetter", "index", "inv", "invert",
+    "itemgetter", "neg", "not_", "pos", "truth"
+}
 locals().update(
-    {name: curry(f) if should_curry(f) else f
-     for name, f in vars(operator).items() if callable(f)},
+    {name: f if name in IGNORE else curry(f)
+     for name, f in vars(operator).items() if callable(f)}
 )
 
 # Clean up the namespace.
+del IGNORE
 del curry
-del num_required_args
-del has_keywords
 del operator
-del should_curry

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -3,9 +3,7 @@ import inspect
 import sys
 from operator import attrgetter, not_
 from importlib import import_module
-from textwrap import dedent
 from types import MethodType
-import sys
 
 from .utils import no_default
 
@@ -780,6 +778,8 @@ class excepts(object):
 
     @instanceproperty(classval=__doc__)
     def __doc__(self):
+        from textwrap import dedent
+
         exc = self.exc
         try:
             if isinstance(exc, tuple):

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -4,7 +4,6 @@ import collections
 import operator
 from functools import partial
 from itertools import filterfalse, zip_longest
-from random import Random
 from collections.abc import Sequence
 from toolz.utils import no_default
 
@@ -1052,5 +1051,7 @@ def random_sample(prob, seq, random_state=None):
     [7, 9, 19, 25, 30, 32, 34, 48, 59, 60, 81, 98]
     """
     if not hasattr(random_state, 'random'):
+        from random import Random
+
         random_state = Random(random_state)
     return filter(lambda _: random_state.random() < prob, seq)

--- a/toolz/tests/test_curried.py
+++ b/toolz/tests/test_curried.py
@@ -41,7 +41,18 @@ def test_module_name():
     assert toolz.curried.__name__ == 'toolz.curried'
 
 
+def should_curry(func):
+    if not callable(func) or isinstance(func, toolz.curry):
+        return False
+    nargs = toolz.functoolz.num_required_args(func)
+    if nargs is None or nargs > 1:
+        return True
+    return nargs == 1 and toolz.functoolz.has_keywords(func)
+
+
 def test_curried_operator():
+    import operator
+
     for k, v in vars(cop).items():
         if not callable(v):
             continue
@@ -60,6 +71,7 @@ def test_curried_operator():
                 raise AssertionError(
                     'toolz.curried.operator.%s is not curried!' % k,
                 )
+        assert should_curry(getattr(operator, k)) == isinstance(v, toolz.curry), k
 
     # Make sure this isn't totally empty.
     assert len(set(vars(cop)) & {'add', 'sub', 'mul'}) == 3
@@ -68,14 +80,6 @@ def test_curried_operator():
 def test_curried_namespace():
     exceptions = import_module('toolz.curried.exceptions')
     namespace = {}
-
-    def should_curry(func):
-        if not callable(func) or isinstance(func, toolz.curry):
-            return False
-        nargs = toolz.functoolz.num_required_args(func)
-        if nargs is None or nargs > 1:
-            return True
-        return nargs == 1 and toolz.functoolz.has_keywords(func)
 
 
     def curry_namespace(ns):


### PR DESCRIPTION
Thanks @fjetter for identifying `toolz.curried.operator` as the main culprit in dask/distributed#6659

The `operator` modules tends to change slowly (although `call` is about to be added!), so this shouldn't be much of a maintenance burden to keep up to date.