### PR TITLE
docs: fix simple typo, argumemts -> arguments

### DIFF
--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -36,7 +36,7 @@ import builtins
 #         not include keyword-only arguments.
 #
 #   keyword_only_args: (optional)
-#       - Tuple of keyword-only argumemts.
+#       - Tuple of keyword-only arguments.
 
 module_info = {}
 


### PR DESCRIPTION
There is a small typo in toolz/_signatures.py.

Should read `arguments` rather than `argumemts`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md