### PR TITLE
Add utils.consume

### DIFF
--- a/toolz/tests/test_utils.py
+++ b/toolz/tests/test_utils.py
@@ -1,6 +1,15 @@
-from toolz.utils import raises
+from toolz.utils import raises, consume
 
 
 def test_raises():
     assert raises(ZeroDivisionError, lambda: 1 / 0)
     assert not raises(ZeroDivisionError, lambda: 1)
+
+
+def test_consume():
+    l = [1, 2, 3]
+    assert consume(l) is None
+    il = iter(l)
+    assert consume(il) is None
+    assert raises(StopIteration, lambda: next(il))
+    assert raises(TypeError, lambda: consume(1))

--- a/toolz/utils.py
+++ b/toolz/utils.py
@@ -1,3 +1,11 @@
+from collections import deque
+
+
+def consume(seq):
+    """Efficently consume an iterable"""
+    deque(seq, maxlen=0)
+
+
 def raises(err, lamda):
     try:
         lamda()


### PR DESCRIPTION
Cytoolz has a utils.consume for consuming an iterable efficiently. This PR resolves the discrepancy in the API by providing an efficient consume function to toolz.