### PR TITLE
Faster check for isiterable

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -283,11 +283,7 @@ def isiterable(x):
     >>> isiterable(5)
     False
     """
-    try:
-        iter(x)
-        return True
-    except TypeError:
-        return False
+    return hasattr(x, "__iter__")
 
 
 def isdistinct(seq):


### PR DESCRIPTION
Use hasattr to check if something is iterable or not by checking specifically for __iter__ method. When the input is not an iterable, catching the exception is expensive.

ping: @eriknw 