### PR TITLE
Add itertoolz.flat

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -1058,7 +1058,9 @@ def random_sample(prob, seq, random_state=None):
 
 
 def flat(level, seq):
-    """ Flatten a sequence by n levels """
+    """ Flatten a possible nested sequence by n levels """
+    if level < 0:
+        raise ValueError("level must be >= 0")
     for item in seq:
         if level == 0 or not hasattr(item, '__iter__'):
             yield item

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -13,7 +13,7 @@ __all__ = ('remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
            'first', 'second', 'nth', 'last', 'get', 'concat', 'concatv',
            'mapcat', 'cons', 'interpose', 'frequencies', 'reduceby', 'iterate',
            'sliding_window', 'partition', 'partition_all', 'count', 'pluck',
-           'join', 'tail', 'diff', 'topk', 'peek', 'peekn', 'random_sample')
+           'join', 'tail', 'diff', 'topk', 'peek', 'peekn', 'random_sample', 'flat')
 
 
 def remove(predicate, seq):
@@ -1055,3 +1055,12 @@ def random_sample(prob, seq, random_state=None):
 
         random_state = Random(random_state)
     return filter(lambda _: random_state.random() < prob, seq)
+
+
+def flat(level, seq):
+    """ Flatten a sequence by n levels """
+    for item in seq:
+        if level == 0 or not hasattr(item, '__iter__'):
+            yield item
+        else:
+            yield from flat(level - 1, item)

--- a/toolz/tests/test_itertoolz.py
+++ b/toolz/tests/test_itertoolz.py
@@ -13,7 +13,7 @@ from toolz.itertoolz import (remove, groupby, merge_sorted,
                              reduceby, iterate, accumulate,
                              sliding_window, count, partition,
                              partition_all, take_nth, pluck, join,
-                             diff, topk, peek, peekn, random_sample)
+                             diff, topk, peek, peekn, random_sample, flat)
 from operator import add, mul
 
 
@@ -547,3 +547,14 @@ def test_random_sample():
     assert mk_rsample(b"a") == mk_rsample(u"a")
 
     assert raises(TypeError, lambda: mk_rsample([]))
+
+
+def test_flat():
+    seq = [1, 2, 3, 4]
+    assert list(flat(0, seq)) == seq
+    assert list(flat(1, seq)) == seq
+
+    seq = [1, [2, [3]]]
+    assert list(flat(0, seq)) == seq
+    assert list(flat(1, seq)) == [1, 2, [3]]
+    assert list(flat(2, seq)) == [1, 2, 3]


### PR DESCRIPTION
An implementation of javascript's Array.flat() (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#use_generator_function)
More flexible than the recipe in itertools.