### PR TITLE
Use "yield from" in merge_sorted

### DIFF
--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -148,8 +148,7 @@ def _merge_sorted_binary(seqs):
     try:
         val2 = next(seq2)
     except StopIteration:
-        for val1 in seq1:
-            yield val1
+        yield from seq1
         return
 
     for val1 in seq1:
@@ -167,12 +166,10 @@ def _merge_sorted_binary(seqs):
             yield val1
     else:
         yield val2
-        for val2 in seq2:
-            yield val2
+        yield from seq2
         return
     yield val1
-    for val1 in seq1:
-        yield val1
+    yield from seq1
 
 
 def _merge_sorted_binary_key(seqs, key):
@@ -191,8 +188,7 @@ def _merge_sorted_binary_key(seqs, key):
     try:
         val2 = next(seq2)
     except StopIteration:
-        for val1 in seq1:
-            yield val1
+        yield from seq1
         return
     key2 = key(val2)
 
@@ -213,12 +209,10 @@ def _merge_sorted_binary_key(seqs, key):
             yield val1
     else:
         yield val2
-        for val2 in seq2:
-            yield val2
+        yield from seq2
         return
     yield val1
-    for val1 in seq1:
-        yield val1
+    yield from seq1
 
 
 def interleave(seqs):


### PR DESCRIPTION
Convert these loops:
```python
for item in seq:
    yield item
```
To the more modern and slightly more efficient
```python
yield from seq
```

A quick benchmark (`a` is a list of 30 sorted lists of 60 random integers)
```
# old
In [8]: %timeit list(merge_sorted(*a))
815 µs ± 31.3 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# new
In [7]: %timeit list(merge_sorted(*a))
766 µs ± 26.2 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
