### PR TITLE
Setup pyright type-checking 

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,0 +1,15 @@
+name: Pyright
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  type-check:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run Pyright
+        uses: jakebailey/pyright-action@v1

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": [
+    "toolz"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    "**/tests"
+  ],
+  "ignore": [
+    "toolz/_version.py"
+  ],
+  "pythonVersion": "3.5",
+  "pythonPlatform": "All",
+  "stubPath": "",
+  "typeCheckingMode": "basic",
+  "reportUnnecessaryTypeIgnoreComment": true
+}

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -222,7 +222,7 @@ class curry(object):
 
         self.__doc__ = getattr(func, '__doc__', None)
         self.__name__ = getattr(func, '__name__', '<curry>')
-        self.__module__ = getattr(func, '__module__', None)
+        self.__module__ = getattr(func, '__module__', None)  # pyright: ignore
         self.__qualname__ = getattr(func, '__qualname__', None)
         self._sigspec = None
         self._has_unknown_args = None
@@ -241,7 +241,7 @@ class curry(object):
 
         params = list(sig.parameters.values())
         skip = 0
-        for param in params[:len(args)]:
+        for param in params[:len(args)]:  # pyright: ignore
             if param.kind == param.VAR_POSITIONAL:
                 break
             skip += 1
@@ -256,8 +256,8 @@ class curry(object):
             elif kind == param.VAR_POSITIONAL:
                 if kwonly:
                     continue
-            elif param.name in keywords:
-                default = keywords[param.name]
+            elif param.name in keywords:  # pyright: ignore
+                default = keywords[param.name]  # pyright: ignore
                 kind = param.KEYWORD_ONLY
                 kwonly = True
             else:
@@ -311,7 +311,7 @@ class curry(object):
         func = self.func
         args = self.args + args
         if self.keywords:
-            kwargs = dict(self.keywords, **kwargs)
+            kwargs = dict(self.keywords, **kwargs)  # pyright: ignore
         if self._sigspec is None:
             sigspec = self._sigspec = _sigs.signature_or_spec(func)
             self._has_unknown_args = has_varargs(func, sigspec) is not False
@@ -390,7 +390,7 @@ def _restore_curry(cls, func, args, kwargs, userdict, is_decorated):
 
 
 @curry
-def memoize(func, cache=None, key=None):
+def memoize(func, cache=None, key=None):  # pyright: ignore
     """ Cache a function's result for speedy future evaluation
 
     Considerations:
@@ -442,7 +442,7 @@ def memoize(func, cache=None, key=None):
             def key(args, kwargs):
                 return args[0]
         elif may_have_kwargs:
-            def key(args, kwargs):
+            def key(args, kwargs):  # pyright: ignore
                 return (
                     args or None,
                     frozenset(kwargs.items()) if kwargs else None,
@@ -495,7 +495,7 @@ class Compose(object):
     def __setstate__(self, state):
         self.first, self.funcs = state
 
-    @instanceproperty(classval=__doc__)
+    @instanceproperty(classval=__doc__)  # pyright: ignore
     def __doc__(self):
         def composed_doc(*fs):
             """Generate a docstring for the composition of fs.
@@ -776,7 +776,7 @@ class excepts(object):
         except self.exc as e:
             return self.handler(e)
 
-    @instanceproperty(classval=__doc__)
+    @instanceproperty(classval=__doc__)  # pyright: ignore
     def __doc__(self):
         from textwrap import dedent
 

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -241,7 +241,7 @@ def interleave(seqs):
                 yield next(itr)
             return
         except StopIteration:
-            predicate = partial(operator.is_not, itr)
+            predicate = partial(operator.is_not, itr)  # pyright: ignore
             iters = itertools.cycle(itertools.takewhile(predicate, iters))
 
 
@@ -625,7 +625,7 @@ def reduceby(key, binop, seq, init=no_default):
                 d[k] = item
                 continue
             else:
-                d[k] = init()
+                d[k] = init()  # pyright: ignore
         d[k] = binop(d[k], item)
     return d
 
@@ -1054,4 +1054,7 @@ def random_sample(prob, seq, random_state=None):
         from random import Random
 
         random_state = Random(random_state)
-    return filter(lambda _: random_state.random() < prob, seq)
+    return filter(
+        lambda _: random_state.random() < prob,  # pyright: ignore
+        seq,
+    )

--- a/toolz/sandbox/core.py
+++ b/toolz/sandbox/core.py
@@ -74,7 +74,7 @@ class EqualityHashKey(object):
         if self.key == self._default_hashkey:
             val = self.key
         else:
-            val = self.key(self.item)
+            val = self.key(self.item)  # pyright: ignore
         return hash(val)
 
     def __eq__(self, other):


### PR DESCRIPTION
I have added
* A basic config file for pyright
* A CI job to run pyright
* comments to ignore errors that pyright detects in existing code. 

This is to type-check any type hints that are added to toolz, as suggested in #496.
These can be added incrementally.