### PR TITLE
iterable Composition object

### DIFF
--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -495,6 +495,10 @@ class Compose(object):
     def __setstate__(self, state):
         self.first, self.funcs = state
 
+    def __iter__(self):
+        yield self.first
+        for f in self.funcs: yield f
+
     @instanceproperty(classval=__doc__)
     def __doc__(self):
         def composed_doc(*fs):

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -496,8 +496,8 @@ class Compose(object):
         self.first, self.funcs = state
 
     def __iter__(self):
+        for f in reversed(self.funcs): yield f
         yield self.first
-        for f in self.funcs: yield f
 
     @instanceproperty(classval=__doc__)
     def __doc__(self):
@@ -513,7 +513,7 @@ class Compose(object):
         try:
             return (
                 'lambda *args, **kwargs: ' +
-                composed_doc(*reversed((self.first,) + self.funcs))
+                composed_doc(*self)
             )
         except AttributeError:
             # One of our callables does not have a `__name__`, whatever.
@@ -523,14 +523,14 @@ class Compose(object):
     def __name__(self):
         try:
             return '_of_'.join(
-                (f.__name__ for f in reversed((self.first,) + self.funcs))
+                (f.__name__ for f in self)
             )
         except AttributeError:
             return type(self).__name__
 
     def __repr__(self):
         return '{.__class__.__name__}{!r}'.format(
-            self, tuple(reversed((self.first, ) + self.funcs)))
+            self, tuple(self))
 
     def __eq__(self, other):
         if isinstance(other, Compose):


### PR DESCRIPTION
I previously suggested that compositions should be iterable in issue https://github.com/pytoolz/toolz/issues/553

I decided to see what that would look like, and have included the code here.  The change is pretty trivial (adding an ```__iter__``` function to the Compose object) and I went ahead and simplified the ```__doc__```, ```__name__```, and ```__repr__``` functions to take advantage of the fact that you can just use ```self``` as an iterable to remove ```reversed((first,)+funcs)```.

I don't know how your tests work, but it seems to work fine with all my code.  The only way I can imagine this breaking anything is if the code ever checks for iterability to decide if something is a Compose object, but I didn't see anything like that.