### PR TITLE
fix doc, add a blank line to show code snippet correctly

### DIFF
--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -757,6 +757,7 @@ class excepts(object):
     -1
 
     Multiple exceptions and default except clause.
+
     >>> excepting = excepts((IndexError, KeyError), lambda a: a[0])
     >>> excepting([])
     >>> excepting([1])


### PR DESCRIPTION
the current API for `excepts` looks like this: https://github.com/wenhoujx/toolz/pull/master
<img width="720" alt="image" src="https://user-images.githubusercontent.com/4370201/230663985-9f2f4fea-cdb7-4438-a8e5-1c4b997797bf.png">

which i think is b/c the missing blank line in the doc comments. 