### PR TITLE
Improve flip to accept *args and kwargs

### DIFF
--- a/toolz/_signatures.py
+++ b/toolz/_signatures.py
@@ -580,7 +580,7 @@ module_info['toolz'] = dict(
     excepts=[
         (0, lambda exc, func, handler=None: None)],
     flip=[
-        (0, lambda func=None, a=None, b=None: None)],
+        (0, lambda func=None, *args, **kwargs: None)],
     juxt=[
         (0, lambda *funcs: None)],
     memoize=[

--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -705,7 +705,7 @@ def do(func, x):
 
 
 @curry
-def flip(func, a, b):
+def flip(func, *args, **kwargs):
     """ Call the function call with the arguments flipped
 
     This function is curried.
@@ -728,7 +728,7 @@ def flip(func, a, b):
     >>> only_ints
     [1, 2, 3]
     """
-    return func(b, a)
+    return func(*reversed(args), **kwargs)
 
 
 def return_none(exc):

--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -735,6 +735,13 @@ def test_flip():
     assert flip(f, 'a', 'b') == ('b', 'a')
 
 
+def test_flip_args_kwargs():
+    def g(a, b, c, *, d, e):
+        return a, b, c, d, e
+
+    assert flip(g, 3, 2, 1, d=4, e=5) == (1, 2, 3, 4, 5)
+
+
 def test_excepts():
     # These are descriptors, make sure this works correctly.
     assert excepts.__name__ == 'excepts'


### PR DESCRIPTION
First, thanks for the great project!

Currently, flip is limited to two arguments, and it does not handle keyword arguments.
I might be missing something, but this seems easy to fix, and should be a non-breaking change.

Let me know if any other changes are needed.