### PR TITLE
LL : typo "Syndey" -> "Sydney"

### DIFF
--- a/doc/source/streaming-analytics.rst
+++ b/doc/source/streaming-analytics.rst
@@ -271,7 +271,7 @@ residences.
 
    >>> cities = [('Alice', 'NYC'),
    ...           ('Alice', 'Chicago'),
-   ...           ('Dan', 'Syndey'),
+   ...           ('Dan', 'Sydney'),
    ...           ('Edith', 'Paris'),
    ...           ('Edith', 'Berlin'),
    ...           ('Zhao', 'Shanghai')]

--- a/toolz/itertoolz.py
+++ b/toolz/itertoolz.py
@@ -828,7 +828,7 @@ def join(leftkey, leftseq, rightkey, rightseq,
 
     >>> cities = [('Alice', 'NYC'),
     ...           ('Alice', 'Chicago'),
-    ...           ('Dan', 'Syndey'),
+    ...           ('Dan', 'Sydney'),
     ...           ('Edith', 'Paris'),
     ...           ('Edith', 'Berlin'),
     ...           ('Zhao', 'Shanghai')]


### PR DESCRIPTION
Hello,
I just found this typo while reading the doc.
Best regards,
   Laurent Lyaudet