### PR TITLE
Test fixes for changes in recent upstream Python (#581)

### DIFF
--- a/toolz/tests/test_functoolz.py
+++ b/toolz/tests/test_functoolz.py
@@ -738,10 +738,13 @@ def test_flip():
 def test_excepts():
     # These are descriptors, make sure this works correctly.
     assert excepts.__name__ == 'excepts'
+    # in Python < 3.13 the second line is indented, in 3.13+
+    # it is not, strip all lines to fudge it
+    testlines = "\n".join((line.strip() for line in excepts.__doc__.splitlines()))
     assert (
         'A wrapper around a function to catch exceptions and\n'
-        '    dispatch to a handler.\n'
-    ) in excepts.__doc__
+        'dispatch to a handler.\n'
+    ) in testlines
 
     def idx(a):
         """idx docstring


### PR DESCRIPTION
This includes a couple of fixes for changes in recent Python: 3.13 deindents docstrings, and a fix for inspecting wrappers was landed in 3.13 and backported to 3.12.3 and 3.11.9, which breaks the expectations of the `test_inspect_wrapped_property` test.

Note a couple of tests still fail against current Python 3.13 due to https://github.com/python/cpython/issues/120526 . I did not want to upstream a workaround for that to toolz, since the correct fix is for the `map` signature to be corrected in Python: https://github.com/python/cpython/pull/120528 fixes that.