### PR TITLE
Declare support for Python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(name='toolz',
           "Programming Language :: Python :: 3.10",
           "Programming Language :: Python :: 3.11",
           "Programming Language :: Python :: 3.12",
+          "Programming Language :: Python :: 3.13",
           "Programming Language :: Python :: Implementation :: CPython",
           "Programming Language :: Python :: Implementation :: PyPy"])

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py310
     py311
     py312
+    py313
     pypy3
 
 skip_missing_interpreters = true


### PR DESCRIPTION
Adds the PyPI trove classifier for Python 3.13.

https://pyreadiness.org/3.13/