### PR TITLE
Use correct URL for test-pypi for publishing test wheels

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Publish to Test-PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
+          repository-url: https://test.pypi.org/legacy/
           print-hash: true
           verbose: true
 


### PR DESCRIPTION
Continuation of #607 